### PR TITLE
ci: use Codecov token for reliable coverage uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-prospective:
     name: Test (ubuntu / Python 3.15-dev, experimental)


### PR DESCRIPTION
Adds `CODECOV_TOKEN` secret reference to the coverage upload step. Tokenless uploads are being deprecated and are unreliable for public repos.