### PR TITLE
ci: run nightly from main; document trunk-based branching

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,9 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: dev
+          # Integration branch: nightlies match default development (trunk on main).
+          ref: main
           persist-credentials: false
-      - name: Check for recent commits on dev
+      - name: Check for recent commits on main
         id: check
         run: |
           if [ "${{ github.event_name }}" != "schedule" ]; then
@@ -32,15 +33,15 @@ jobs:
             exit 0
           fi
           if [ -n "$(git rev-list --after='25 hours' HEAD)" ]; then
-            echo "New commits on dev in the last 25 hours"
+            echo "New commits on main in the last 25 hours"
             echo "should_build=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No new commits on dev — skipping build"
+            echo "No new commits on main — skipping build"
             echo "should_build=false" >> "$GITHUB_OUTPUT"
           fi
 
   nightly:
-    name: Build & publish dev release
+    name: Build & publish nightly
     needs: check
     if: needs.check.outputs.should_build == 'true'
     runs-on: ubuntu-latest
@@ -53,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: dev
+          ref: main
           persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,13 @@ just dev
 `just dev` runs `just setup` (install deps, git hooks) then `just test`.
 That single command is all you need to go from clone to green test suite.
 
+**Branching:** day-to-day work lands on `main` through pull requests. We do
+not use a long-lived `dev` branch. If a **patch to an old release** is ever
+needed, branch from the **release tag** (or a short-lived `maint-x.y` branch
+forked from that tag), fix, and tag a patch version—this is the usual
+Python-library pattern, not a standing “integrate in dev, promote to main”
+split.
+
 ## Common commands
 
 Run `just` with no arguments to see all available recipes, organized by
@@ -156,8 +163,8 @@ We don't cut releases manually. The flow is:
 
 ### Nightly builds
 
-A scheduled workflow (`nightly.yml`) runs once a day. It stamps a
-`.devYYYYMMDD` suffix on the current `pyproject.toml` version, builds
+A scheduled workflow (`nightly.yml`) runs once a day against **`main`**. It
+stamps a `.devYYYYMMDD` suffix on the current `pyproject.toml` version, builds
 sdist + wheel, and publishes to **TestPyPI**. To install a nightly:
 
 ```bash


### PR DESCRIPTION
Align Nightly (Test PyPI) with trunk development on `main` and document the branching model (PRs to `main`, backports from tags if needed). Removes reliance on a long-lived `dev` ref for scheduled builds.