### PR TITLE
ci(renovate): use github app client-id variable and hardened workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,3 +1,12 @@
+# Self-hosted Renovate using a GitHub App (recommended: short-lived installation tokens).
+# See: https://github.com/renovatebot/github-action#token
+# See: https://github.com/actions/create-github-app-token#readme
+# Do not use GITHUB_TOKEN as the Renovate platform token (PRs may not run CI).
+#
+# Required configuration (repository or `renovate` environment):
+#   - Variable: RENOVATE_GITHUB_APP_CLIENT_ID  (App “Client ID” on github.com/settings/apps; not secret)
+#   - Secret:   RENOVATE_APP_PRIVATE_KEY       (PEM; generate once, store only here)
+
 name: Renovate
 
 on:
@@ -27,13 +36,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Generate token
+      - name: GitHub App installation token
         id: token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          # Client ID (not the numeric “App ID”): see App → General, or actions/create-github-app-token README
+          client-id: ${{ vars.RENOVATE_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
-          repositories: ${{ github.event.repository.name }}
+          # Unset `repositories` = token scoped to this repository only (action default)
           permission-contents: write
           permission-pull-requests: write
           permission-checks: write
@@ -52,5 +62,5 @@ jobs:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_ONBOARDING: "false"
           RENOVATE_REQUIRE_CONFIG: "optional"
-          RENOVATE_DRY_RUN: ${{ inputs.dry-run && 'full' || 'null' }}
+          RENOVATE_DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && (inputs.dry-run == 'true' || inputs.dry-run == true)) && 'full' || '' }}
           LOG_LEVEL: info

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,27 +195,41 @@ If you edit `renovate.json`, run `just renovate-validate` to check it
 against the official schema before pushing.
 
 <details>
-<summary>Maintainer setup (GitHub App token)</summary>
+<summary>Maintainer setup (GitHub App)</summary>
 
-The Renovate workflow authenticates via a GitHub App to get short-lived
-tokens (no long-lived PATs). One-time setup:
+The Renovate workflow uses a [GitHub App](https://docs.github.com/en/apps) so
+each run gets a **short-lived installation token** (no long-lived PAT).
+This matches the
+[installation-token action README](https://github.com/actions/create-github-app-token#readme)
+and [Renovate’s GitHub platform docs](https://docs.renovatebot.com/modules/platform/github/#running-as-a-github-app).
+
+One-time setup:
 
 1. [Create a GitHub App](https://github.com/settings/apps/new) with these
    repository permissions:
    - **Read+write:** Contents, Pull requests, Checks, Commit statuses,
      Issues, Workflows
    - **Read-only:** Administration, Vulnerability alerts, Members
-2. Install the app on the `chad-loder/pyhaul` repository.
-3. Create a GitHub **environment** named `renovate` in the repository
-   settings (Settings > Environments). Optionally restrict it to the
-   `main` branch.
-4. Add the app's numeric ID as an environment secret named
-   `RENOVATE_APP_ID`.
-5. Generate a private key and add it as an environment secret named
-   `RENOVATE_APP_PRIVATE_KEY`.
+2. **Install the app** on the `chad-loder/pyhaul` repository.
+3. Create a GitHub **environment** named `renovate` (Settings →
+   Environments). You can require deployment branches or approvers; keep
+   secrets in this environment or at repo level consistently with the
+   workflow.
+4. **Client ID (variable, not a secret):** On the app’s **General** page,
+   copy **Client ID** and add a **repository or environment variable** named
+   `RENOVATE_GITHUB_APP_CLIENT_ID`. See the
+   [installation-token action README](https://github.com/actions/create-github-app-token#readme)
+   for the `client-id` input (use **Client ID**, not the numeric “App ID”).
+5. **Private key (secret):** Generate a private key for the app, and add
+   **one** of:
+   - an environment secret `RENOVATE_APP_PRIVATE_KEY` on `renovate`, or
+   - the same name as a **repository** secret,
 
-The workflow runs weekly on Monday mornings and can be triggered manually
-from the Actions tab (with an optional dry-run mode).
+   with the full PEM (including `BEGIN/END` lines). GitHub masks it in
+   logs.
+
+The workflow runs weekly (Monday 04:00 UTC) and can be run manually from
+**Actions → Renovate → Run workflow** (optional dry-run).
 
 </details>
 


### PR DESCRIPTION
Implements the pattern from [actions/create-github-app-token](https://github.com/actions/create-github-app-token): **Client ID** in a repository/environment **variable** (`RENOVATE_GITHUB_APP_CLIENT_ID`), private key in **`RENOVATE_APP_PRIVATE_KEY`**. Replaces deprecated `app-id` secret; fixes `RENOVATE_DRY_RUN` for scheduled runs; drops redundant `repositories` (default is current repo only). Updates CONTRIBUTING maintainer setup.

**After merge**, add the variable and ensure the secret is set (see CONTRIBUTING). Remove obsolete `RENOVATE_APP_ID` if it was only the numeric App ID.