### PR TITLE
ci(renovate): drop admin and vulnerability-alerts from token

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -51,8 +51,6 @@ jobs:
           permission-statuses: read
           permission-issues: write
           permission-workflows: write
-          permission-administration: read
-          permission-vulnerability-alerts: read
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@83ec54fee49ab67d9cd201084c1ff325b4b462e4 # v46.1.10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,13 +206,16 @@ and [Renovate’s GitHub platform docs](https://docs.renovatebot.com/modules/pla
 One-time setup:
 
 1. [Create a GitHub App](https://github.com/settings/apps/new) with these
-   repository permissions (must be **at least** what the workflow requests
-   when minting the installation token):
+   repository permissions (must **match or exceed** what
+   `.github/workflows/renovate.yml` passes to the installation token):
    - **Read+write:** Contents, Pull requests, Issues, Workflows
-   - **Read:** Administration, Checks, Commit statuses, Vulnerability alerts
-   - **Optional (organizations):** Members (read) if you use org features;
-     the workflow does **not** request `members` so user-only installs avoid
-     `422` from the token step.
+   - **Read:** Checks, Commit statuses
+   - **Optional (extra Renovate features):** add **Read** for Administration
+     and **Read** for **Vulnerability alerts** (Dependabot) on the app, then
+     add `permission-administration: read` and
+     `permission-vulnerability-alerts: read` to the workflow—otherwise omit
+     both. **Optional (organizations):** Members (read); the workflow does
+     not request it.
 2. **Install the app** on the `chad-loder/pyhaul` repository. If you skip
    this, the `GitHub App installation token` step fails with `404` from
    the [installation


### PR DESCRIPTION
Further narrows the installation token to avoid `422` when the app has the core repository scopes but not Administration or Vulnerability alerts (Dependabot) read.

CONTRIBUTING: optional scopes for full OSV/branch-protection behavior.