### PR TITLE
ci(renovate): restore admin and vulnerability-alerts on install token

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -51,6 +51,8 @@ jobs:
           permission-statuses: read
           permission-issues: write
           permission-workflows: write
+          permission-administration: read
+          permission-vulnerability-alerts: read
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@83ec54fee49ab67d9cd201084c1ff325b4b462e4 # v46.1.10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,13 +209,10 @@ One-time setup:
    repository permissions (must **match or exceed** what
    `.github/workflows/renovate.yml` passes to the installation token):
    - **Read+write:** Contents, Pull requests, Issues, Workflows
-   - **Read:** Checks, Commit statuses
-   - **Optional (extra Renovate features):** add **Read** for Administration
-     and **Read** for **Vulnerability alerts** (Dependabot) on the app, then
-     add `permission-administration: read` and
-     `permission-vulnerability-alerts: read` to the workflow—otherwise omit
-     both. **Optional (organizations):** Members (read); the workflow does
-     not request it.
+   - **Read:** Administration, Checks, Commit statuses, **Vulnerability alerts**
+     (Dependabot; required for `vulnerabilityAlerts` / OSV in `renovate.json`)
+   - **Optional (organizations):** Members (read); the workflow does not
+     request it.
 2. **Install the app** on the `chad-loder/pyhaul` repository. If you skip
    this, the `GitHub App installation token` step fails with `404` from
    the [installation


### PR DESCRIPTION
## Why

`renovate.json` enables `vulnerabilityAlerts` and `osvVulnerabilityAlerts`. Those use GitHub APIs that require `vulnerability_alerts:read` on the **installation access token**. The workflow had stopped passing `permission-vulnerability-alerts: read` to `create-github-app-token`, so the token did not include that scope even when the app allowed it—Renovate logs **Cannot access vulnerability alerts**.

## Change

- Restore `permission-administration: read` and `permission-vulnerability-alerts: read` on the token step (same as GitHub App **Read** for Administration and Dependabot/Vulnerability alerts).
- CONTRIBUTING: list those as required for this repo config, not optional.

After merge, re-approve the app installation if GitHub prompts for new permissions.