### PR TITLE
chore: rollup docs, deps, engine, build, and just quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ __pycache__/
 *.pyo
 *.egg-info/
 dist/
-build/
+# Root only — avoid ignoring ``scripts/build/`` (e.g. PyPI README generator).
+/build/
 
 # Tool caches
 .venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
-* add RFC-style SPEC.md and fix rumdl command in justfile ([#12](https://github.com/chad-loder/pyhaul/issues/12)) ([183eeda](https://github.com/chad-loder/pyhaul/commit/183eeda5cb1b5202ed953bd4ce40aeb8ae9825e6))
-* finalize SPEC.md (alignment + strategy) ([#14](https://github.com/chad-loder/pyhaul/issues/14)) ([734f4c7](https://github.com/chad-loder/pyhaul/commit/734f4c78e08a0d78103b516456d0f19ce9fd5f48))
+* add RFC-style `docs/SPEC.md` and fix rumdl command in justfile ([#12](https://github.com/chad-loder/pyhaul/issues/12)) ([183eeda](https://github.com/chad-loder/pyhaul/commit/183eeda5cb1b5202ed953bd4ce40aeb8ae9825e6))
+* finalize `docs/SPEC.md` (alignment + strategy) ([#14](https://github.com/chad-loder/pyhaul/issues/14)) ([734f4c7](https://github.com/chad-loder/pyhaul/commit/734f4c78e08a0d78103b516456d0f19ce9fd5f48))
 * update checkpoint format description to binary ([#9](https://github.com/chad-loder/pyhaul/issues/9)) ([661de1c](https://github.com/chad-loder/pyhaul/commit/661de1ccd50b8986fa8a201bc44ebb585501d0de))
 
 ## [0.3.0](https://github.com/chad-loder/pyhaul/compare/v0.2.1...v0.3.0) (2026-04-26)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to pyhaul
 
 Thanks for your interest in contributing. This document covers the dev
-environment, the commit/PR conventions, and the release workflow.
+environment and how we use commits and pull requests.
 
 ## Prerequisites
 
@@ -20,12 +20,8 @@ just dev
 `just dev` runs `just setup` (install deps, git hooks) then `just test`.
 That single command is all you need to go from clone to green test suite.
 
-**Branching:** day-to-day work lands on `main` through pull requests. We do
-not use a long-lived `dev` branch. If a **patch to an old release** is ever
-needed, branch from the **release tag** (or a short-lived `maint-x.y` branch
-forked from that tag), fix, and tag a patch version—this is the usual
-Python-library pattern, not a standing “integrate in dev, promote to main”
-split.
+**Branching:** work on a topic branch and open pull requests to **`main`**. We
+do not use a long-lived `dev` branch.
 
 ## Common commands
 
@@ -36,7 +32,7 @@ group:
 $ just
 Available recipes:
     [build]
-    build             # Generate PyPI README and build sdist + wheel
+    build             # Regenerate docs/PYPI_README.md then build sdist + wheel
 
     [ci]
     ci                # Full CI run (setup + pre-commit + pytest with coverage)
@@ -54,6 +50,7 @@ Available recipes:
     lint-all          # Run all linters (contributor + maintainer)
     lint-fix          # Auto-fix everything fixable, then check
     lint-maintainer   # Lint workflows, actions security, and CI config (maintainer-facing)
+    maintain          # uv sync then maintainer lints (workflows, schemas, zizmor)
     test              # Run test suite
 ```
 
@@ -65,6 +62,7 @@ The most common workflow:
 | `just check` | Before pushing (runs lint + test) |
 | `just lint` | Quick lint-only pass (code, shell, docs) |
 | `just lint-maintainer` | Lint workflows and CI config (actionlint, zizmor, schemas) |
+| `just maintain` | `uv sync` then same as `lint-maintainer` (refresh env first) |
 | `just lint-all` | Both `lint` + `lint-maintainer` |
 | `just lint-fix` | Auto-fix lint issues, then check |
 | `just test` | Run pytest |
@@ -147,105 +145,14 @@ Subject lines should:
 - not end with a period
 - be in the imperative mood (`add`, not `adds` / `added`)
 
-## Release workflow
-
-We don't cut releases manually. The flow is:
-
-1. Merge PRs to `main`. Each PR title is a conventional commit.
-2. On every push to `main`, the **Release** workflow runs
-   [`release-please`](https://github.com/googleapis/release-please),
-   which opens or updates a **"Release PR"** with the next version,
-   updated `CHANGELOG.md`, and bumped `pyproject.toml`.
-3. When ready to release, merge the Release PR. That triggers:
-   - A git tag (e.g. `v0.2.0`) and a GitHub Release.
-   - The `publish` job, which builds via `uv build` and publishes to
-     PyPI using **Trusted Publishing** (OIDC; no API tokens).
-
-### Nightly builds
-
-A scheduled workflow (`nightly.yml`) runs once a day against **`main`**. It
-stamps a `.devYYYYMMDD` suffix on the current `pyproject.toml` version, builds
-sdist + wheel, and publishes to **TestPyPI**. To install a nightly:
-
-```bash
-uv pip install --index-url https://test.pypi.org/simple/ \
-               --extra-index-url https://pypi.org/simple/ \
-               pyhaul
-```
-
 ## Dependency updates
 
-Dependencies are kept current automatically by
-[Renovate](https://docs.renovatebot.com/), running as a self-hosted
-GitHub Actions workflow (no third-party app install). The configuration
-lives in `renovate.json` and applies these policies:
-
-- **7-day cooldown** on all new releases (Python deps, pre-commit hooks,
-  GitHub Actions) to let the community catch malicious or broken packages
-  before we adopt them.
-- **Vulnerability fixes skip the cooldown** and are labeled `security`.
-- **Dev/lint tools** (ruff, mypy, pyright, etc.) and **test deps** (pytest,
-  hypothesis, etc.) are grouped into single PRs and automerged via branch
-  merge on patch/minor bumps if CI passes. Pre-1.0 packages are excluded
-  from automerge.
-- **Lock file maintenance** runs weekly.
-- **OSV vulnerability summary** appears on the Dependency Dashboard issue.
-
-If you edit `renovate.json`, run `just renovate-validate` to check it
-against the official schema before pushing.
-
-<details>
-<summary>Maintainer setup (GitHub App)</summary>
-
-The Renovate workflow uses a [GitHub App](https://docs.github.com/en/apps) so
-each run gets a **short-lived installation token** (no long-lived PAT).
-This matches the
-[installation-token action README](https://github.com/actions/create-github-app-token#readme)
-and [Renovate’s GitHub platform docs](https://docs.renovatebot.com/modules/platform/github/#running-as-a-github-app).
-
-One-time setup:
-
-1. [Create a GitHub App](https://github.com/settings/apps/new) with these
-   repository permissions (must **match or exceed** what
-   `.github/workflows/renovate.yml` passes to the installation token):
-   - **Read+write:** Contents, Pull requests, Issues, Workflows
-   - **Read:** Administration, Checks, Commit statuses, **Vulnerability alerts**
-     (Dependabot; required for `vulnerabilityAlerts` / OSV in `renovate.json`)
-   - **Optional (organizations):** Members (read); the workflow does not
-     request it.
-2. **Install the app** on the `chad-loder/pyhaul` repository. If you skip
-   this, the `GitHub App installation token` step fails with `404` from
-   the [installation
-   API](https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app)
-   (no installation for the app on that repo). If the install exists but
-   the token step returns **`422` The permissions requested are not granted**,
-   the app’s permissions (or the [installation
-   update](https://github.com/settings/installations)) are missing something
-   the workflow asks for—align them or relax the token inputs in
-   `.github/workflows/renovate.yml`.
-3. Create a GitHub **environment** named `renovate` (Settings →
-   Environments). You can require deployment branches or approvers; keep
-   secrets in this environment or at repo level consistently with the
-   workflow.
-4. **Client ID (variable, not a secret):** On the app’s **General** page,
-   copy **Client ID** and add a **repository or environment variable** named
-   `RENOVATE_GITHUB_APP_CLIENT_ID`. See the
-   [installation-token action README](https://github.com/actions/create-github-app-token#readme)
-   for the `client-id` input (use **Client ID**, not the numeric “App ID”).
-5. **Private key (secret):** Generate a private key for the app, and add
-   **one** of:
-   - an environment secret `RENOVATE_APP_PRIVATE_KEY` on `renovate`, or
-   - the same name as a **repository** secret,
-
-   with the full PEM (including `BEGIN/END` lines). GitHub masks it in
-   logs.
-
-The workflow runs weekly (Monday 04:00 UTC) and can be run manually from
-**Actions → Renovate → Run workflow** (optional dry-run).
-
-</details>
+Dependency bumps are usually handled by a scheduled [Renovate](https://docs.renovatebot.com/)
+workflow; its configuration is in `renovate.json`. If you edit that file,
+run `just renovate-validate` to check it against the official schema before
+you push.
 
 ## Reporting security issues
 
-See [`SECURITY.md`](SECURITY.md). Please do **not** file public issues
-for vulnerabilities.
+See [`SECURITY.md`](SECURITY.md) for scope and how to report (including
+**public PRs or issues** if you prefer an open fix).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyhaul
 
-[![CI](https://github.com/chad-loder/pyhaul/actions/workflows/ci.yml/badge.svg)](https://github.com/chad-loder/pyhaul/actions/workflows/ci.yml)
+[![CI](https://github.com/chad-loder/pyhaul/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/chad-loder/pyhaul/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/chad-loder/pyhaul/graph/badge.svg)](https://codecov.io/gh/chad-loder/pyhaul)
 [![PyPI](https://img.shields.io/pypi/v/pyhaul.svg)](https://pypi.org/project/pyhaul/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
@@ -59,6 +59,35 @@ Each call to `haul()` upholds these guarantees:
   creates, configures, or closes sessions.
 - **Transport errors pass through unwrapped.** `httpx.ReadTimeout`
   stays `httpx.ReadTimeout`. You catch the types you already know.
+
+## How it fits into your code
+
+One `haul()` = one HTTP request. It either succeeds and returns
+`CompleteHaul`, or it throws — possibly after saving progress
+to a `.part` file that allows the next call to resume. `pyhaul` never
+creates sessions, connections, or clients. Your HTTP library's native
+exceptions propagate through unwrapped, so you can drop `haul()`
+into existing code without changing your error handling. Retries are
+your call — a for-loop, `tenacity`, or nothing. Concurrency limiting
+(e.g. `asyncio.Semaphore`) is also yours — `pyhaul` downloads one
+file per call and doesn't manage parallelism.
+
+```python
+def haul(url, client, *, dest, state=None) -> CompleteHaul: ...
+async def haul_async(url, client, *, dest, state=None) -> CompleteHaul: ...
+```
+
+`state` is an optional `HaulState` bag, updated in-place as bytes
+land on disk — works identically in sync and async. See
+[docs/DESIGN.md](docs/DESIGN.md) for the exception hierarchy, transport
+adapters, and download lifecycle.
+
+## Documentation
+
+- **[docs/DESIGN.md](docs/DESIGN.md)** — Transport adapters, checkpoint state, and the download lifecycle.
+- **[docs/WHY.md](docs/WHY.md)** — Silent failure modes in HTTP range/resume, and how pyhaul compares
+  to `curl`, `wget`, and `aria2c`.
+- **[docs/SPEC.md](docs/SPEC.md)** — Control file and checkpoint format (implementers / compatible tools).
 
 <!-- pypi-end -->
 
@@ -140,28 +169,6 @@ state.
 
 <!-- See doc_todo.md for future README section ideas. -->
 
-## How it fits into your code
-
-One `haul()` = one HTTP request. It either succeeds and returns
-`CompleteHaul`, or it throws — possibly after saving progress
-to a `.part` file that allows the next call to resume. `pyhaul` never
-creates sessions, connections, or clients. Your HTTP library's native
-exceptions propagate through unwrapped, so you can drop `haul()`
-into existing code without changing your error handling. Retries are
-your call — a for-loop, `tenacity`, or nothing. Concurrency limiting
-(e.g. `asyncio.Semaphore`) is also yours — `pyhaul` downloads one
-file per call and doesn't manage parallelism.
-
-```python
-def haul(url, client, *, dest, state=None) -> CompleteHaul: ...
-async def haul_async(url, client, *, dest, state=None) -> CompleteHaul: ...
-```
-
-`state` is an optional `HaulState` bag, updated in-place as bytes
-land on disk — works identically in sync and async. See
-[DESIGN.md](DESIGN.md) for the exception hierarchy, transport
-adapters, and download lifecycle.
-
 ## Why this exists
 
 You probably already know that resuming an HTTP download isn't just
@@ -169,7 +176,7 @@ You probably already know that resuming an HTTP download isn't just
 than most people expect — servers that return 200 instead of 206,
 resources that change between retries (`curl -C -` and `aria2c` both
 miss this), compression that corrupts resumed streams, and ordering
-guarantees needed for crash safety. See [WHY.md](WHY.md) for the
+guarantees needed for crash safety. See [docs/WHY.md](docs/WHY.md) for the
 deep-dive and a comparison with `curl`, `wget`, and `aria2c`.
 
 ## Install
@@ -186,16 +193,11 @@ pip install pyhaul[aiohttp]    # aiohttp (async)
 
 No hard dependency on any HTTP library. Pick one (or several) as extras.
 
-## Documentation
-
-- **[DESIGN.md](DESIGN.md)** — Transport adapters, checkpoint state, and the download lifecycle.
-- **[WHY.md](WHY.md)** — Silent failure modes in HTTP range/resume, and how pyhaul compares
-  to `curl`, `wget`, and `aria2c`.
-- **[docs/SPEC.md](docs/SPEC.md)** — Control file and checkpoint format (implementers / compatible tools).
-
 ---
 
 ## Development
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for branches, commit style, and full tooling.
 
 ```bash
 git clone https://github.com/chad-loder/pyhaul.git && cd pyhaul

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,16 @@
 
 ## Reporting a vulnerability
 
-If you discover a security issue in `pyhaul`, please report it privately
-via GitHub's security advisory workflow:
+We prefer **transparency**: if you find a security problem in `pyhaul`, you are
+welcome to open a **pull request** (or a public **issue** if a PR is not
+practical) so the fix and any discussion can happen in the open.
+
+If you need **private coordination** first—for example, you believe disclosure
+should wait until a patch is ready—use GitHub’s security advisory flow:
 
 **<https://github.com/chad-loder/pyhaul/security/advisories/new>**
 
-Do **not** open a public GitHub issue, pull request, or discussion for a
-vulnerability. We aim to acknowledge reports within 72 hours.
+In either case, we aim to acknowledge reports within 72 hours.
 
 ## Supported versions
 
@@ -29,6 +32,6 @@ In scope:
 
 Out of scope:
 
-- Issues in dependencies (report to `bitarray`, `niquests`, etc. directly).
+- Issues in dependencies (report to `httpx`, `niquests`, etc. directly).
 - Attacks that require local filesystem access or a compromised host.
 - Self-DoS from passing absurd inputs to the API.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,5 +1,7 @@
 # Design
 
+**See also:** [Specification (on-disk format)](SPEC.md) · [Why pyhaul exists](WHY.md) · [README](../README.md)
+
 ## Exceptions
 
 | Exception | When | Retryable? |
@@ -52,8 +54,8 @@ testing, etc.), implement the `TransportSession` protocol: a single
 4. **200 OK** — server ignores the range (resource changed, or server
    doesn't support ranges). Cursor resets to 0; stream overwrites from
    the beginning.
-5. **416 Range Not Satisfiable** — cursor equals resource length
-   (already complete) or resource shrank (checkpoint reset, next call
-   restarts).
+5. **416 Range Not Satisfiable** — the server’s reported total matches
+   the cursor (already complete) or the representation shrank (checkpoint
+   reset, next call restarts).
 
 The engine handles each case without caller intervention.

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -1,6 +1,6 @@
 # pyhaul
 
-[![CI](https://github.com/chad-loder/pyhaul/actions/workflows/ci.yml/badge.svg)](https://github.com/chad-loder/pyhaul/actions/workflows/ci.yml)
+[![CI](https://github.com/chad-loder/pyhaul/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/chad-loder/pyhaul/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/chad-loder/pyhaul/graph/badge.svg)](https://codecov.io/gh/chad-loder/pyhaul)
 [![PyPI](https://img.shields.io/pypi/v/pyhaul.svg)](https://pypi.org/project/pyhaul/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/chad-loder/pyhaul/blob/main/LICENSE)
@@ -32,27 +32,30 @@ with httpx.Client() as client:
 ## What is it?
 
 A small, pure-Python library that makes HTTP downloads **resumable**.
-Call `haul()` with your existing HTTP client, a URL, and a destination
-path — it handles byte-range negotiation, ETag validation, crash-safe
-checkpointing, and atomic file completion. Sync and async; works with
-requests, httpx, niquests, urllib3, and **aiohttp** (async).
+To download a file, call `haul()` with a URL, your existing HTTP
+client, and a destination path. **pyhaul** handles byte-range
+negotiation for resume, ETag validation, crash-safe
+checkpointing, and atomic file completion. Supports both sync and
+async across multiple HTTP client libraries.
 
 Each call to `haul()` upholds these guarantees:
 
-- **The destination file is either complete or absent.** There is no
-  state where a partially-written file sits at the final path.
-  Incomplete data lives in a temporary `.part` file; on completion
+- **One `haul()` makes one request**. You are responsible for
+  retry loops, but retry just means call `haul()` again.
+- **The destination file will not exist until download is complete.**
+  There is no state where a partially-written file sits at the final
+  path. Incomplete data lives in a temporary `.part` file; on completion
   it is atomically moved into place.
-- **Interrupted downloads resume, not restart.** Checkpoint state
+- **Interrupted downloads resume when possible.** Checkpoint state
   lives on disk, not in memory. Kill the process, lose the network,
   get a 503 — the next `haul()` picks up from the last durable
   byte. Zero re-downloaded data if the resource hasn't changed.
-- **Changed resources are detected, not silently corrupted.** If
+- **If the remote resource changes, retry will not corrupt.** If
   the remote file changes between attempts, `pyhaul` detects the
   mismatch via ETag (a server-side fingerprint) and starts over
   cleanly instead of gluing mismatched halves together.
 - **Your HTTP client is borrowed, not owned.** `pyhaul` sets
-  per-request headers and returns the session untouched. It never
+  per-request headers and returns your session untouched. It never
   creates, configures, or closes sessions.
 - **Transport errors pass through unwrapped.** `httpx.ReadTimeout`
   stays `httpx.ReadTimeout`. You catch the types you already know.
@@ -76,11 +79,12 @@ async def haul_async(url, client, *, dest, state=None) -> CompleteHaul: ...
 
 `state` is an optional `HaulState` bag, updated in-place as bytes
 land on disk — works identically in sync and async. See
-[DESIGN.md](https://github.com/chad-loder/pyhaul/blob/main/DESIGN.md) for the exception hierarchy, transport
+[docs/DESIGN.md](https://github.com/chad-loder/pyhaul/blob/main/docs/DESIGN.md) for the exception hierarchy, transport
 adapters, and download lifecycle.
 
 ## Documentation
 
-- **[Design](https://github.com/chad-loder/pyhaul/blob/main/DESIGN.md)** — transport adapters, checkpoint state, download lifecycle
-- **[Why this exists](https://github.com/chad-loder/pyhaul/blob/main/WHY.md)** — failure modes and comparison with `curl` / `wget` / `aria2c`
-- **[Specification](https://github.com/chad-loder/pyhaul/blob/main/docs/SPEC.md)** — control file format
+- **[docs/DESIGN.md](https://github.com/chad-loder/pyhaul/blob/main/docs/DESIGN.md)** — Transport adapters, checkpoint state, and the download lifecycle.
+- **[docs/WHY.md](https://github.com/chad-loder/pyhaul/blob/main/docs/WHY.md)** — Silent failure modes in HTTP range/resume, and how pyhaul compares
+  to `curl`, `wget`, and `aria2c`.
+- **[docs/SPEC.md](https://github.com/chad-loder/pyhaul/blob/main/docs/SPEC.md)** — Control file and checkpoint format (implementers / compatible tools).

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,10 +1,11 @@
-# pyhaul Specification v1.0
+# pyhaul Control File Format Specification, Version 1.0
 
-## Status of this Memo
-
-This document specifies the binary format and operational rules for the
-pyhaul resumable downloader. It is intended for implementers of the
-pyhaul protocol and compatible tools.
+This specification defines **version 1** of the on-disk control file: the
+one-byte `Version` field in the header is the unsigned value `1` (octet
+`0x01`). It specifies
+binary layout, TLV metadata, and operational requirements for the pyhaul
+resumable downloader. The intended audience is implementers and authors of
+compatible tools.
 
 ## 1. Introduction
 
@@ -21,7 +22,7 @@ For a destination file `dest.bin`, the following artifacts are managed:
 - `dest.bin.part.ctrl`: The binary checkpoint (the "Control File").
 - `dest.bin`: The final, verified product (only exists upon success).
 
-## 3. Control File Binary Format (v4)
+## 3. Control File Binary Format (v1)
 
 All multi-byte integers are encoded in Little-Endian byte order.
 
@@ -36,7 +37,7 @@ framed TLV extensions, null padding for alignment, and finally the hash payload.
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                      Magic (b"HAUL")                          |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|  Version (4)  |  Reserved (0) |         HeaderSize            |
+|  Ver. (=1)    |  Reserved (0) |         HeaderSize            |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                         Cursor (64-bit)                       +
@@ -65,7 +66,7 @@ framed TLV extensions, null padding for alignment, and finally the hash payload.
 ### 3.2. Field Definitions
 
 - **Magic (4 bytes):** The literal ASCII string `b"HAUL"`.
-- **Version (1 byte):** Unsigned integer. Currently `4`.
+- **Version (1 byte):** Unsigned integer. Currently `1` (the only defined format).
 - **Reserved (1 byte):** Must be `0`.
 - **HeaderSize (2 bytes):** Total offset in bytes from the start of the file to
   the beginning of the Hashes Payload. This pointer allows parsers to jump to
@@ -100,7 +101,7 @@ control file from causing the parser to misinterpret lengths or ETag strings.
 Supported Tags:
 
 - `1`: ETag (UTF-8 string)
-- `2`: Resource Length (64-bit unsigned integer — the full remote file size)
+- `2`: Reported length (64-bit unsigned integer — server-claimed full size)
 - `3`: Tail Hash (32-byte SHA-256 binary digest of the current partial block)
 
 ### 3.4. Hashes Payload

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -1,5 +1,7 @@
 # Why pyhaul exists
 
+**See also:** [Design](DESIGN.md) · [Specification](SPEC.md) · [README](../README.md)
+
 I wanted something that made resuming HTTP downloads easy. Not just
 "add a Range header" easy — actually easy, where you call a function,
 it either finishes or it doesn't, and in both cases the state on disk

--- a/justfile
+++ b/justfile
@@ -1,43 +1,99 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 set no-exit-message
 
+# `LINT_VERBOSE`: per-tool “Running …” lines (dim) before quiet linters (unset ⇒ auto-on in CI).
+# CI / verbosity are pure Just (`~/dev/just/tests/conditional.rs`). `quote` + `\` continuation for bundle assembly.
+
+export LINT_VERBOSE := env('LINT_VERBOSE', '')
+ok_msg := '''\033[32m  ok\033[0m'''
+
+[private]
+_lv := trim(env('LINT_VERBOSE', ''))
+
+# Mirrors the previous Bash CI probe. `\` continuation so `:=` parses (~/dev/just/manual multi-line constructs).
+[private]
+_is_ci := if env('CI', '') == 'true' { 'yes' } else if env('CI', '') == '1' { 'yes' } else if env('CONTINUOUS_INTEGRATION', '') != '' { 'yes' } else if env('GITHUB_ACTIONS', '') != '' { 'yes' } else if env('GITLAB_CI', '') != '' { 'yes' } else if env('BUILDKITE', '') != '' { 'yes' } else if env('CIRCLECI', '') != '' { 'yes' } else if env('JENKINS_URL', '') != '' { 'yes' } else if env('TRAVIS', '') != '' { 'yes' } else if env('APPVEYOR', '') != '' { 'yes' } else if env('TF_BUILD', '') != '' { 'yes' } else if env('SYSTEM_TEAMFOUNDATIONCOLLECTIONURI', '') != '' { 'yes' } else { '' }
+
+# Empty `LINT_VERBOSE` ⇒ defer to `_is_ci`. Explicit tokens override; unknown nonempty ⇒ never emit “Running…”.
+[private]
+_show_running := if _lv == '' { if _is_ci == 'yes' { 'yes' } else { '' } } else if _lv == '1' { 'yes' } else if _lv == 'true' { 'yes' } else if _lv == 'TRUE' { 'yes' } else if _lv == 'yes' { 'yes' } else if _lv == 'YES' { 'yes' } else if _lv == 'on' { 'yes' } else if _lv == 'ON' { 'yes' } else if _lv == '0' { '' } else if _lv == 'false' { '' } else if _lv == 'FALSE' { '' } else if _lv == 'no' { '' } else if _lv == 'NO' { '' } else if _lv == 'off' { '' } else if _lv == 'OFF' { '' } else { '' }
+
+[private]
+_shell_export := 'export JUST_SHOW_RUNNING=' + quote(_show_running)
+
+[private]
+_bash_lint_helpers := '''
+  JUST_DIM=$'\033[2m'
+  JUST_GREEN=$'\033[32m'
+  JUST_RST=$'\033[0m'
+  lint_running() {
+    [[ "${JUST_SHOW_RUNNING:-}" == "yes" ]] || return 0
+    printf '%s  ·  Running %s%s\n' "$JUST_DIM" "$1" "$JUST_RST" >&2
+  }
+  lint_ok() {
+    printf '%s  ok%s  %s\n' "$JUST_GREEN" "$JUST_RST" "$1" >&2
+  }
+  run_semgrep() {
+    lint_running "semgrep"
+    local _tmp _code
+    _tmp=$(mktemp) || { echo "semgrep: mktemp failed" >&2; return 1; }
+    set +e
+    uv run semgrep scan --config=auto --quiet --emacs --error --disable-version-check src/ 2>"$_tmp"
+    _code=$?
+    set -e
+    if [ -s "$_tmp" ]; then
+      grep -vE '^[┌│└├].*|^[[:space:]]*Semgrep[[:space:]]+CLI|^[[:space:]]*╭' "$_tmp" | sed '/^[[:space:]]*$/d' >&2 || true
+    fi
+    rm -f "$_tmp"
+    if [ "$_code" -eq 0 ]; then
+      lint_ok "semgrep"
+    fi
+    return "$_code"
+  }
+'''
+
+[private]
+_lint_bundle := _shell_export + "\n" + _bash_lint_helpers
+
 [private]
 default:
     @just --list
 
 # --- Quality ---
+# (`[group]` is for `just --list`; it is unrelated to PEP 735 `[dependency-groups]`.)
 
-# Lint code, shell, docs, and spelling (contributor-facing)
+[doc('Lint tracked Python, shell, docs, spelling (contributor-facing)')]
 [group('quality')]
 lint: _lint-py _lint-sh _lint-docs _lint-spell
-    @printf '\033[32m✓ lint\033[0m\n'
+    @printf '%b  %s\n' "{{ ok_msg }}" "lint" >&2
 
-# Lint workflows, actions security, and CI config (maintainer-facing)
 [group('quality')]
 lint-maintainer: _lint-workflows
-    @printf '\033[32m✓ lint-maintainer\033[0m\n'
+    @printf '%b  %s\n' "{{ ok_msg }}" "lint-maintainer" >&2
 
-# Run all linters (contributor + maintainer)
+[doc('`uv sync`, then workflow / security tooling (matches `maintain` PEP 735 deps)')]
 [group('quality')]
-lint-all: _lint-py _lint-sh _lint-docs _lint-spell _lint-workflows
-    @printf '\033[32m✓ lint-all\033[0m\n'
+maintain:
+    uv sync
+    @{{ just_executable() }} _lint-workflows
+    @printf '%b  %s\n' "{{ ok_msg }}" "maintain" >&2
 
-# Auto-fix everything fixable, then check
+[group('quality')]
+lint-all: lint lint-maintainer
+    @printf '%b  %s\n' "{{ ok_msg }}" "lint-all" >&2
+
 [group('quality')]
 lint-fix: _lint-py-fix _lint-sh-fix _lint-docs-fix
 
-# Run test suite
 [group('quality')]
 test:
     uv run pytest
 
-# Lint and test (pre-push sanity check)
 [group('quality')]
 check: lint test
 
 # --- Build ---
 
-# Generate PyPI README and build sdist + wheel
 [group('build')]
 build:
     uv run scripts/build/pypi_readme.py
@@ -45,11 +101,9 @@ build:
 
 # --- Dev ---
 
-# Setup environment and run tests (first-time onboarding)
 [group('dev')]
 dev: setup test
 
-# Install deps, hooks, and tools
 [group('dev')]
 setup:
     uv sync --all-groups
@@ -57,44 +111,55 @@ setup:
     uv run pre-commit install --install-hooks
     @{{ just_executable() }} _setup-hooks
 
-# Run the pyhaul CLI from source tree
 [group('dev')]
 run-cli *ARGS:
     uv run python -m pyhaul {{ ARGS }}
 
-# Remove caches and build artifacts
 [group('dev')]
 clean:
-    uvx pyclean . --debris all
+    uv run pyclean . --debris all
 
 # --- CI ---
 
-# Full CI run (setup + pre-commit + pytest with coverage)
 [group('ci')]
 ci: setup
     uv run pre-commit run --all-files --show-diff-on-failure
     uv run coverage run -m pytest
     uv run coverage xml -o coverage.xml
 
-# Validate renovate.json against official schema
 [group('ci')]
 renovate-validate:
-    @uvx check-jsonschema --schemafile "https://docs.renovatebot.com/renovate-schema.json" renovate.json
+    @uv run check-jsonschema --schemafile "https://docs.renovatebot.com/renovate-schema.json" renovate.json
 
-# --- Private sub-recipes (callable directly, hidden from --list) ---
+# --- Private ---
 
 [private]
 _lint-py:
     #!/usr/bin/env bash
     set -euo pipefail
+    {{ _lint_bundle }}
+    lint_running "ruff check"
     uv run ruff check --quiet .
+    lint_ok "ruff check"
+    lint_running "ruff format"
     uv run ruff format --quiet --check .
-    uv run mypy --no-error-summary src tests examples
+    lint_ok "ruff format"
+    lint_running "mypy"
+    uv run mypy --no-error-summary src tests examples scripts
+    lint_ok "mypy"
+    lint_running "pyright"
     _out=$(uv run pyright 2>&1) || { echo "$_out"; exit 1; }
+    lint_ok "pyright"
+    lint_running "ty"
     uv run ty check --quiet --quiet
+    lint_ok "ty"
+    lint_running "validate-pyproject"
     uv run validate-pyproject pyproject.toml > /dev/null
+    lint_ok "validate-pyproject"
+    lint_running "interrogate"
     uv run interrogate --quiet src/pyhaul/
-    uv run semgrep scan --config=auto --quiet --emacs --error src/
+    lint_ok "interrogate"
+    run_semgrep
 
 [private]
 _lint-py-fix:
@@ -105,6 +170,11 @@ _lint-py-fix:
 _lint-sh:
     #!/usr/bin/env bash
     set -euo pipefail
+    command -v shellcheck >/dev/null || {
+      echo 'error: install shellcheck (e.g. brew install shellcheck)' >&2
+      exit 1
+    }
+    {{ _lint_bundle }}
     targets=()
     while IFS= read -r _f; do
         targets+=("$_f")
@@ -113,41 +183,55 @@ _lint-sh:
         [[ -f "$hook" ]] && targets+=("$hook")
     done
     (( ${#targets[@]} == 0 )) && exit 0
-    command -v shellcheck >/dev/null || { echo "error: install shellcheck (e.g. brew install shellcheck)" >&2; exit 1; }
+    lint_running "shellcheck"
     shellcheck -f quiet -x "${targets[@]}"
+    lint_ok "shellcheck"
 
 [private]
 _lint-sh-fix:
-    #!/usr/bin/env bash
-    set +e
-    {{ just_executable() }} _lint-sh
-    _exit=$?
-    set -e
-    printf '\033[33mNote: shellcheck has no auto-fix mode — review the output above and fix manually.\033[0m\n' >&2
-    exit $_exit
+    @{{ just_executable() }} _lint-sh || (printf '\033[33mNote: shellcheck has no auto-fix mode — review the output above and fix manually.\033[0m\n' >&2 && exit 1)
 
 [private]
 _lint-docs:
-    @uvx rumdl check --quiet .
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{ _lint_bundle }}
+    lint_running "rumdl"
+    uv run rumdl check --quiet .
+    lint_ok "rumdl"
 
 [private]
 _lint-workflows:
     #!/usr/bin/env bash
     set -euo pipefail
-    command -v actionlint >/dev/null || { echo "error: install actionlint (e.g. brew install actionlint)" >&2; exit 1; }
+    command -v actionlint >/dev/null || {
+      echo 'error: install actionlint (e.g. brew install actionlint)' >&2
+      exit 1
+    }
+    {{ _lint_bundle }}
+    lint_running "actionlint"
     actionlint -no-color
-    uvx check-jsonschema --schemafile "https://docs.renovatebot.com/renovate-schema.json" renovate.json
-    uvx zizmor -q .
+    lint_ok "actionlint"
+    lint_running "check-jsonschema (renovate.json)"
+    uv run check-jsonschema --schemafile "https://docs.renovatebot.com/renovate-schema.json" renovate.json
+    lint_ok "check-jsonschema (renovate.json)"
+    lint_running "zizmor"
+    uv run zizmor -q .
+    lint_ok "zizmor"
 
 [private]
 _lint-docs-fix:
-    uvx rumdl fmt .
+    uv run rumdl fmt .
 
 [private]
 _lint-spell:
-    @uv run codespell src tests docs examples *.md *.toml
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{ _lint_bundle }}
+    lint_running "codespell"
+    uv run codespell src tests docs examples scripts *.md *.toml
+    lint_ok "codespell"
 
-# Copies tracked hook scripts into .git/hooks, aborting on local edits.
 [private]
 _safe-install src dest:
     #!/usr/bin/env bash
@@ -156,6 +240,9 @@ _safe-install src dest:
     _dest={{ quote(dest) }}
     SOURCE_HASH=$(git hash-object "$_src")
     DEST_HASH=$(git hash-object "$_dest" 2>/dev/null || echo "none")
+    if [[ "$DEST_HASH" != "none" ]] && [[ "$SOURCE_HASH" == "$DEST_HASH" ]]; then
+      exit 0
+    fi
     if [[ "$DEST_HASH" != "none" && "$SOURCE_HASH" != "$DEST_HASH" ]]; then
       if ! git rev-list --all --objects | grep -q "$DEST_HASH"; then
         echo "ERROR: Local changes in $_dest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ["uv_build>=0.11,<0.12"]
+requires = ["uv_build>=0.11.7,<0.12"]
 build-backend = "uv_build"
 
 [project]
 name = "pyhaul"
 version = "0.4.0"
 description = "Resumable, cursor-based, CDN-safe HTTP downloads for Python"
-readme = "PYPI_README.md"
+readme = "docs/PYPI_README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.12"
@@ -74,11 +74,8 @@ source-exclude = [
 
 [dependency-groups]
 # PEP 735 — not published as installable extras; for contributors / CI only.
-test = [
-    "pytest>=8",
-    "pytest-cov>=6",
-    "hypothesis>=6",
-    "anyio>=4",
+# All optional HTTP stacks for the test suite (mirrors optional-extras version floors).
+compat-all = [
     "niquests>=3.14",
     "requests>=2.32",
     "types-requests>=2.33.0.20260408",
@@ -86,24 +83,45 @@ test = [
     "urllib3>=2.0",
     "aiohttp>=3.10",
 ]
+test = [
+    { include-group = "compat-all" },
+    "pytest>=9.0.3",
+    "pytest-cov>=7.1.0",
+    "hypothesis>=6.152.1",
+    "anyio>=4.13.0",
+]
 lint = [
-    "ruff>=0.15",
-    "mypy>=1.13,<1.20",
-    "pre-commit>=4",
-    "pyright>=1.1.400",
-    "tenacity>=9",
-    "markdown-it-py>=4,<5",
-    "ty>=0.0.1",
-    "codespell>=2.4",
+    "ruff>=0.15.11",
+    "mypy>=1.19.1,<1.20",
+    "pre-commit>=4.5.1",
+    "pyright>=1.1.408",
+    "tenacity>=9.1.4",
+    "markdown-it-py>=4.0.0,<5",
+    "ty>=0.0.31",
+    "codespell>=2.4.2",
     "validate-pyproject[all]>=0.25",
-    "semgrep>=1",
-    "interrogate>=1.7",
+    "semgrep>=1.160.0",
+    "interrogate>=1.7.0",
+]
+# Extra tooling (not needed for the library at runtime) — pyclean for cache cleaning.
+dev = [
+    "pyclean>=3.6.0",
+]
+# Maintainer / CI-surface tools (workflows, Renovate, markdown policy). Includes `dev`
+# (pyclean) so `just clean` and maintainer lints share one resolved set.
+maintainer = [
+    { include-group = "dev" },
+    "rumdl>=0.1.76",
+    "check-jsonschema>=0.37.1",
+    "zizmor>=1.24.1",
 ]
 
 [tool.uv]
-default-groups = ["test", "lint"]
+default-groups = ["test", "lint", "maintainer"]
 # Resolver cutoff: ignore PyPI uploads newer than this (relative to lock/sync resolve time).
-exclude-newer = "48h"
+# 72h balances fast incident response on PyPI with a buffer past typical detection and
+# weekend-drop windows. For an urgent CVE fix: `uv lock --exclude-newer=0h --upgrade-package <name>`.
+exclude-newer = "72h"
 
 # ---------------------------------------------------------------------------
 # Tool configuration
@@ -175,7 +193,9 @@ terms = ["TODO", "FIXME", "XXX", "HACK"]
 ".github/PULL_REQUEST_TEMPLATE.md" = ["MD041"]
 "SECURITY.md" = ["MD036"]
 "README.md" = ["MD044", "MD061"]
-"PYPI_README.md" = ["MD044", "MD061"]
+"docs/PYPI_README.md" = ["MD044", "MD061"]
+# release-please output: list style / blank lines differ from repo-wide markdown rules
+"CHANGELOG.md" = ["MD004", "MD012"]
 
 [tool.ruff]
 line-length = 120
@@ -238,6 +258,7 @@ known-first-party = ["pyhaul"]
 ]
 "**/conftest.py" = ["D", "ARG", "S101", "SLF001", "A002", "N802", "C901"]
 "examples/**" = ["T20", "INP001", "D", "ASYNC240"]
+"scripts/**" = ["T20", "INP001", "D"]
 
 [tool.ruff.format]
 quote-style = "double"
@@ -269,7 +290,7 @@ exclude = '''(?x)(
 pythonVersion = "3.12"
 pythonPlatform = "All"
 typeCheckingMode = "strict"
-include = ["src", "tests", "examples"]
+include = ["src", "tests", "examples", "scripts"]
 exclude = [".venv", "build", "dist", "**/__pycache__"]
 
 # Tests need repo root on the path for ``from tests.…``; relax noisy rules there only.
@@ -293,6 +314,13 @@ extraPaths = ["src"]
 reportUnknownParameterType = false
 reportUnknownArgumentType = false
 reportMissingTypeStubs = false
+
+[[tool.pyright.executionEnvironments]]
+root = "scripts"
+reportMissingTypeStubs = false
+reportUnknownVariableType = false
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
 
 # ---------------------------------------------------------------------------
 # ty  (Astral's Rust-based type checker — scoped to library code only)

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,14 @@
       "minimumReleaseAge": "7 days"
     },
     {
+      "description": "PEP 735: bump >= for maintainer tooling",
+      "matchManagers": ["pep621"],
+      "matchJsonata": [
+        "depType = 'dependency-groups' and managerData.depGroup in ['lint', 'test', 'dev', 'maintainer']"
+      ],
+      "rangeStrategy": "bump"
+    },
+    {
       "description": "Group lint/dev tool updates into a single PR",
       "groupName": "lint tools",
       "matchManagers": ["pep621"],

--- a/scripts/build/pypi_readme.py
+++ b/scripts/build/pypi_readme.py
@@ -1,0 +1,105 @@
+"""Generate docs/PYPI_README.md from README.md.
+
+Parses README.md with markdown-it-py to find a <!-- pypi-end --> HTML comment
+marker, slices the document at that boundary (respecting code fences), rewrites
+repo-relative links to absolute GitHub URLs, and writes the result.
+
+Usage:
+    uv run scripts/build/pypi_readme.py            # generate / update
+    uv run scripts/build/pypi_readme.py --check    # exit 1 if out of date
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlparse
+
+from markdown_it import MarkdownIt
+
+PYPROJECT = Path("pyproject.toml")
+MARKER = "pypi-end"
+SRC = Path("README.md")
+DEST = Path("docs/PYPI_README.md")
+
+RELATIVE_LINK_RE = re.compile(r"\[([^\]]+)\]\((?!https?://)([^)]+)\)")
+
+
+def rewrite_relative_links(text: str, base_url: str) -> str:
+    """Convert repo-relative markdown links to absolute GitHub URLs."""
+    text = RELATIVE_LINK_RE.sub(rf"[\1]({base_url}/\2)", text)
+    # Badges use nested image+link, e.g. [![License](img.svg)](LICENSE) — the
+    # single-pass regex can miss the outer (LICENSE) target; fix the common case.
+    return text.replace("](LICENSE)", f"]({base_url}/LICENSE)")
+
+
+def slice_at_marker(text: str, marker: str) -> str:
+    """Truncate markdown at an HTML comment containing *marker*.
+
+    Uses markdown-it-py so that markers inside fenced code blocks or inline
+    code are correctly ignored.
+    """
+    md = MarkdownIt("commonmark", {"html": True})
+    for token in md.parse(text):
+        if token.type == "html_block" and marker in token.content and token.map is not None:
+            return "\n".join(text.split("\n")[: token.map[0]]).rstrip() + "\n"
+    return text
+
+
+def repo_blob_url() -> str:
+    """Read project.urls.Source from pyproject.toml and derive the blob URL."""
+    cfg = tomllib.loads(PYPROJECT.read_text())
+    source = cfg["project"]["urls"]["Source"]
+    parsed = urlparse(source)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        _die(f"project.urls.Source is not a valid HTTP(S) URL: {source!r}")
+    normalized = parsed._replace(path=str(PurePosixPath(parsed.path) / "blob" / "main"))
+    return str(normalized.geturl())
+
+
+def generate() -> str:
+    """Build the PyPI README text from README.md."""
+    text = SRC.read_text()
+    text = slice_at_marker(text, MARKER)
+    return rewrite_relative_links(text, repo_blob_url())
+
+
+def _die(msg: str) -> None:
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    for required in (SRC, PYPROJECT):
+        if not required.exists():
+            _die(f"{required} not found (run from repo root)")
+
+    check = "--check" in sys.argv[1:]
+    expected = generate()
+
+    if check:
+        current = DEST.read_text() if DEST.exists() else None
+        if current == expected:
+            sys.exit(0)
+        print(
+            f"{DEST} is {'missing' if current is None else 'out of date'}.\n"
+            f"{DEST} is generated from {SRC} by slicing at the <!-- {MARKER} --> comment\n"
+            f"and rewriting relative links. To fix, run:\n"
+            f"\n"
+            f"    uv run scripts/build/pypi_readme.py\n"
+            f"\n"
+            f"Then stage the updated {DEST} alongside your {SRC} changes.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    else:
+        DEST.write_text(expected)
+        src_size = SRC.stat().st_size
+        pct = f"{100 * len(expected) // src_size}%" if src_size else "n/a"
+        print(f"{DEST}: {len(expected):,} bytes (from {src_size:,}, {pct})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyhaul/_engine_common.py
+++ b/src/pyhaul/_engine_common.py
@@ -10,6 +10,7 @@ finalization.  The only thing each engine owns is the I/O boundary
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import time
 from dataclasses import dataclass, field
@@ -42,6 +43,8 @@ from pyhaul.transport.types import TransportHeaders
 DEFAULT_CHUNK = 1 << 16  # 64 KiB
 DEFAULT_FLUSH = 1 << 20  # 1 MiB
 datasync = getattr(os, "fdatasync", os.fsync)
+
+logger = logging.getLogger(__name__)
 
 _HTTP_200 = 200
 _HTTP_206 = 206
@@ -78,7 +81,7 @@ class StreamPlan:
     cursor: int
     extent: int | None
     etag: ETag
-    resource_length: int | None
+    reported_length: int | None
     content_type: str
     hb: HashBuilder
     bytes_since_flush: int = field(default=0, init=False)
@@ -119,6 +122,16 @@ def prepare_haul(url: str, dest: str | Path) -> PrepareHaul:
         req_hdrs["If-Range"] = str(stored_etag)
     merged = merge_headers({}, {**DEFAULT_HEADERS, **req_hdrs})
 
+    logger.debug(
+        "Prepared download request",
+        extra={
+            "pyhaul_url": str(parsed_url),
+            "pyhaul_dest": str(dest_path),
+            "pyhaul_resume_valid_length": cursor,
+            "pyhaul_request_byte": request_byte,
+        },
+    )
+
     return PrepareHaul(
         dest_path=dest_path,
         parsed_url=parsed_url,
@@ -151,6 +164,14 @@ def handle_response(
     """
     resp_etag = parse_etag(headers.get("ETag"))
     resp_ct = headers.get("Content-Type")
+
+    logger.debug(
+        "HTTP response",
+        extra={
+            "pyhaul_status": status,
+            "pyhaul_etag": str(resp_etag) if resp_etag else "",
+        },
+    )
 
     if status == _HTTP_416:
         return _on_416(headers, prep, state, resp_etag=resp_etag, content_type=resp_ct)
@@ -227,6 +248,13 @@ def _plan_206(
 
     # BUG FIX: Verify ETag if server sent one.
     if resp_etag and prep.stored_etag and resp_etag != prep.stored_etag:
+        logger.debug(
+            "ETag mismatch on 206, aborting",
+            extra={
+                "pyhaul_etag_stored": str(prep.stored_etag),
+                "pyhaul_etag_response": str(resp_etag),
+            },
+        )
         raise ServerMisconfiguredError(f"ETag mismatch on 206: server={resp_etag} stored={prep.stored_etag}")
 
     new_etag = resp_etag or prep.stored_etag
@@ -259,13 +287,23 @@ def _plan_206(
 
     state.block_size = prep.block_size
     state.hashes = hb.completed_hashes.copy()
+    state.reported_length = new_rl
+
+    logger.debug(
+        "Using 206 Partial Content (range response)",
+        extra={
+            "pyhaul_range_start": cr.start,
+            "pyhaul_reported_length": new_rl,
+            "pyhaul_extent": new_extent,
+        },
+    )
 
     return StreamPlan(
         start=prep.start,
         cursor=prep.cursor,
         extent=new_extent,
         etag=new_etag,
-        resource_length=new_rl,
+        reported_length=new_rl,
         content_type=content_type,
         hb=hb,
     )
@@ -283,13 +321,19 @@ def _plan_200(
 
     state.valid_length = 0
     state.hashes = []
+    state.reported_length = resp_cl
+
+    logger.debug(
+        "Using 200 full representation (ignoring range)",
+        extra={"pyhaul_content_length": resp_cl},
+    )
 
     return StreamPlan(
         start=0,
         cursor=0,
         extent=resp_cl,
         etag=resp_etag,
-        resource_length=resp_cl,
+        reported_length=resp_cl,
         content_type=content_type,
         hb=HashBuilder(block_size=state.block_size),
     )
@@ -407,7 +451,7 @@ def _reset_checkpoint(ctrl_path: Path, start: int, block_size: int) -> None:
         block_size=block_size,
         hashes=[],
         tail_hash=None,
-        resource_length=None,
+        reported_length=None,
     )
     write_atomic(ctrl_path, registry.dump(cp))
 
@@ -422,7 +466,7 @@ def _save_checkpoint(path: Path, plan: StreamPlan, _prep: PrepareHaul) -> None:
         block_size=plan.hb.block_size,
         hashes=plan.hb.completed_hashes.copy(),
         tail_hash=plan.hb.current_digest,
-        resource_length=plan.resource_length,
+        reported_length=plan.reported_length,
     )
     write_atomic(path, registry.dump(cp))
 

--- a/src/pyhaul/_types.py
+++ b/src/pyhaul/_types.py
@@ -107,11 +107,18 @@ class HaulState:
     ``valid_length`` is **not monotonic across attempts**: a server
     response that invalidates prior progress rewinds the cursor to
     zero.
+
+    ``reported_length`` is the total size of the resource as claimed by
+    the server, derived from the ``Content-Range`` (complete-length) or
+    ``Content-Length`` headers.  It may be ``None`` if the server omits
+    the total, and may not match the final on-disk size if the server
+    misbehaves.  (Useful for progress UIs.)
     """
 
     is_complete: bool = False
     bytes_read: int = 0
     valid_length: int = 0
+    reported_length: int | None = None
     block_size: int = 8 * 1024 * 1024
     hashes: list[bytes] = field(default_factory=list[bytes])
 

--- a/src/pyhaul/async_engine.py
+++ b/src/pyhaul/async_engine.py
@@ -8,7 +8,9 @@ chunk iterator differ (``async with`` / ``async for``).
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
+from collections.abc import Callable
 from pathlib import Path
 
 from pyhaul._engine_common import (
@@ -28,6 +30,8 @@ from pyhaul._types import CompleteHaul, HaulState
 from pyhaul.transport.errors import TransportError
 from pyhaul.transport.protocols import AsyncTransportSession
 
+logger = logging.getLogger(__name__)
+
 
 async def haul_async(
     url: str,
@@ -37,6 +41,7 @@ async def haul_async(
     state: HaulState | None = None,
     chunk_size: int = DEFAULT_CHUNK,
     flush_every: int = DEFAULT_FLUSH,
+    on_progress: Callable[[HaulState], None] | None = None,
 ) -> CompleteHaul:
     """Async equivalent of :func:`pyhaul.engine.haul`.
 
@@ -50,6 +55,9 @@ async def haul_async(
     *state*, when provided, is a :class:`HaulState` updated in-place
     throughout the download — always accurate regardless of how the
     function exits.
+
+    *on_progress*, if set, is called after each chunk (synchronous
+    callback; same contract as :func:`pyhaul.engine.haul`).
 
     Returns :class:`CompleteHaul` on success.  Raises
     :class:`PartialHaulError` when the stream ends before all bytes
@@ -70,10 +78,16 @@ async def haul_async(
                 return action
 
             plan = action
+            logger.debug(
+                "Beginning response body stream",
+                extra={"pyhaul_part_path": str(prep.part_path)},
+            )
             fd = open_part_file(plan, prep.part_path)
             try:
                 async for chunk in resp.aiter_raw_bytes(chunk_size=chunk_size):
                     write_chunk(fd, chunk, plan, prep, state, flush_every)
+                    if on_progress is not None:
+                        on_progress(state)
                 datasync(fd)
             except TransportError:
                 flush_dirty(fd, plan, prep)

--- a/src/pyhaul/checkpoint.py
+++ b/src/pyhaul/checkpoint.py
@@ -1,8 +1,9 @@
-"""Thread-safe, versioned checkpoint codecs and migration management.
+"""Thread-safe, versioned checkpoint encoding for the control file.
 
-This module follows a registry pattern for format versions.  All codecs are
-stateless and thread-safe.  The Registry handles dispatching and transparent
-migration from legacy formats (like the original JSON V3).
+The registry holds one :class:`CheckpointCodec` per supported on-disk
+version.  Today only *v1* (binary ``HAUL``) exists; the version byte
+in the header is the literal ``1``.  A future *v2* would add another
+codec and bump :data:`LATEST_VERSION`.
 """
 
 from __future__ import annotations
@@ -16,14 +17,12 @@ from typing import Final, Protocol, runtime_checkable
 
 from pyhaul._types import ControlFileError, ETag, parse_etag
 
-# --- Version Constants ---
-
-V3_JSON: Final = 3
-V4_BINARY: Final = 4
-LATEST_VERSION: Final = V4_BINARY
+# On-disk / wire version (v1 is the only format today).
+V1_BINARY: Final = 1
+LATEST_VERSION: Final = V1_BINARY
 
 _MIN_BINARY_SIZE: Final = 5
-_RL_FIELD_SIZE: Final = 8
+_REPORTED_LEN_U64_SIZE: Final = 8
 _CRC_SIZE: Final = 4
 _ALIGNMENT: Final = 8
 
@@ -33,7 +32,7 @@ class Tag(IntEnum):
     """TLV tags for variable-length metadata in the binary format."""
 
     ETAG = 1
-    RESOURCE_LENGTH = 2
+    REPORTED_LENGTH = 2
     TAIL_HASH = 3
 
 
@@ -52,40 +51,39 @@ class Checkpoint:
     block_size: int
     hashes: list[bytes] = field(default_factory=list[bytes])
     tail_hash: bytes | None = None
-    resource_length: int | None = None
+    reported_length: int | None = None
 
 
-# --- Codec Interface ---
+# --- Codec interface ---
 
 
 @runtime_checkable
 class CheckpointCodec(Protocol):
-    """Protocol for version-specific serialization logic."""
+    """Stateless, version-tagged (de)serialization. Subclass for each on-disk version."""
 
     @property
     def version(self) -> int:
-        """The format version number this codec handles."""
+        """The format version number in the binary header (byte index 4 of ``HAUL`` files)."""
         ...
 
     def encode(self, cp: Checkpoint) -> bytes:
-        """Serialize a Checkpoint into raw bytes."""
+        """Serialize a checkpoint into the wire format for :attr:`version`."""
         ...
 
     def decode(self, data: bytes) -> Checkpoint:
-        """Parse raw bytes into a Checkpoint."""
+        """Parse bytes for this codec's format into a :class:`Checkpoint`."""
         ...
 
 
-# --- V4 Binary Implementation ---
+# --- v1 (binary) ---
 
 
-class V4BinaryCodec:
-    """Binary format with framed TLVs and 8-byte payload alignment."""
+class V1BinaryCodec:
+    """Framed TLVs and 8-byte hash payload alignment."""
 
-    version: int = V4_BINARY
+    version: int = V1_BINARY
 
     # Magic(4s), Ver(B), Reserved(B), HeaderSize(H), Cursor(Q), BlockSize(Q), Extent(Q), Start(Q)
-    # Total fixed size = 40 bytes
     _CORE_FORMAT: Final = "<4sBBHQQQQ"
     _CORE_SIZE: Final = struct.calcsize(_CORE_FORMAT)
     _MAGIC: Final = b"HAUL"
@@ -98,36 +96,28 @@ class V4BinaryCodec:
         return payload + struct.pack("<I", crc)
 
     def encode(self, cp: Checkpoint) -> bytes:
-        """Serialize Checkpoint to V4 binary format."""
-        # 1. Build Framed TLV Extensions
+        """Serialize checkpoint to bytes."""
         extensions = bytearray()
 
-        # ETag
         if cp.etag:
             extensions.extend(self._pack_tlv(Tag.ETAG, cp.etag.encode("utf-8")))
 
-        # Resource Length
-        if cp.resource_length is not None:
-            extensions.extend(self._pack_tlv(Tag.RESOURCE_LENGTH, struct.pack("<Q", cp.resource_length)))
+        if cp.reported_length is not None:
+            extensions.extend(self._pack_tlv(Tag.REPORTED_LENGTH, struct.pack("<Q", cp.reported_length)))
 
-        # Tail Hash
         if cp.tail_hash:
             extensions.extend(self._pack_tlv(Tag.TAIL_HASH, cp.tail_hash))
 
-        # --- Alignment Padding ---
-        # Calculate padding to ensure hashes start on an 8-byte boundary
         unaligned_header_size = self._CORE_SIZE + len(extensions)
         padding_needed = (_ALIGNMENT - (unaligned_header_size % _ALIGNMENT)) % _ALIGNMENT
         extensions.extend(b"\x00" * padding_needed)
 
-        # Tail Hash
         if cp.tail_hash:
             extensions.extend(struct.pack("<BH", Tag.TAIL_HASH, len(cp.tail_hash)))
             extensions.extend(cp.tail_hash)
 
         header_size = self._CORE_SIZE + len(extensions)
 
-        # 2. Pack Header
         core = struct.pack(
             self._CORE_FORMAT,
             self._MAGIC,
@@ -140,7 +130,6 @@ class V4BinaryCodec:
             cp.start,
         )
 
-        # 3. Assemble full payload
         payload = bytearray(core)
         payload.extend(extensions)
         for h in cp.hashes:
@@ -149,7 +138,7 @@ class V4BinaryCodec:
         return bytes(payload)
 
     def decode(self, data: bytes) -> Checkpoint:
-        """Parse V4 binary bytes into a Checkpoint."""
+        """Parse bytes in this format into a :class:`Checkpoint`."""
         if len(data) < self._CORE_SIZE:
             raise ControlFileError("file too small for binary header")
 
@@ -158,10 +147,8 @@ class V4BinaryCodec:
         if magic != self._MAGIC:
             raise ControlFileError(f"invalid magic bytes: {magic!r}")
 
-        # 2. Safely Parse Framed TLVs
-        etag, res_len, tail_hash = self._parse_extensions(data, h_size)
+        etag, reported_len, tail_hash = self._parse_extensions(data, h_size)
 
-        # 3. Slice the Hashes Payload (guaranteed to be 8-byte aligned)
         hashes_data = data[h_size:]
         if len(hashes_data) % 32 != 0:
             raise ControlFileError("corrupt hash payload: not a multiple of 32 bytes")
@@ -177,18 +164,16 @@ class V4BinaryCodec:
             block_size=b_size,
             hashes=hashes,
             tail_hash=tail_hash,
-            resource_length=res_len,
+            reported_length=reported_len,
         )
 
     def _parse_extensions(self, data: bytes, header_size: int) -> tuple[ETag, int | None, bytes | None]:
-        """Parse TLV chunks from the header area."""
         etag = ETag("")
-        res_len = None
-        tail_hash = None
+        reported_len: int | None = None
+        tail_hash: bytes | None = None
 
         ptr = self._CORE_SIZE
         while ptr < header_size:
-            # Check if we hit padding (Tag 0x00)
             if data[ptr] == 0:
                 break
 
@@ -201,7 +186,6 @@ class V4BinaryCodec:
             if ptr + chunk_total_len > header_size:
                 raise ControlFileError(f"TLV {tag_val} length {v_len} exceeds header bounds")
 
-            # Extract data and CRC for validation
             chunk_data = data[ptr : ptr + 3 + v_len]
             stored_crc = struct.unpack("<I", data[ptr + 3 + v_len : ptr + chunk_total_len])[0]
 
@@ -212,83 +196,45 @@ class V4BinaryCodec:
 
             if tag_val == Tag.ETAG:
                 etag = parse_etag(value.decode("utf-8"))
-            elif tag_val == Tag.RESOURCE_LENGTH and v_len == _RL_FIELD_SIZE:
-                res_len = struct.unpack("<Q", value)[0]
+            elif tag_val == Tag.REPORTED_LENGTH and v_len == _REPORTED_LEN_U64_SIZE:
+                reported_len = struct.unpack("<Q", value)[0]
             elif tag_val == Tag.TAIL_HASH:
                 tail_hash = value
 
             ptr += chunk_total_len
 
-        return etag, res_len, tail_hash
+        return etag, reported_len, tail_hash
 
 
-# --- Legacy V3 JSON Codec ---
-
-
-class V3LegacyCodec:
-    """Minimal shim for migrating from old JSON checkpoints."""
-
-    version: int = V3_JSON
-
-    def encode(self, cp: Checkpoint) -> bytes:
-        """V3 is read-only."""
-        raise NotImplementedError("V3 is read-only; use V4 for writing")
-
-    def decode(self, data: bytes) -> Checkpoint:
-        """Parse legacy JSON bytes into a modern Checkpoint."""
-        import json
-
-        try:
-            obj = json.loads(data.decode("utf-8"))
-            return Checkpoint(
-                version=self.version,
-                start=obj.get("start", 0),
-                extent=obj.get("extent"),
-                valid_length=obj.get("valid_length", 0),
-                etag=parse_etag(str(obj.get("etag", ""))),
-                block_size=8 * 1024 * 1024,  # Migrated files adopt the default
-                hashes=[],
-                tail_hash=None,
-                resource_length=obj.get("resource_length"),
-            )
-        except Exception as e:
-            raise ControlFileError(f"corrupt legacy JSON: {e}") from e
-
-
-# --- Registry and Dispatch ---
+# --- Registry ---
 
 
 class CheckpointRegistry:
-    """Thread-safe dispatcher for checkpoint serialization."""
+    """Dispatch :meth:`load` / :meth:`dump` to the codec for each format version."""
 
     def __init__(self, codecs: Mapping[int, CheckpointCodec]) -> None:
         self._codecs = dict(codecs)
+        for v, c in self._codecs.items():
+            if c.version != v:
+                msg = f"codec map mismatch: key {v} != codec.version {c.version}"
+                raise ValueError(msg)
 
     def load(self, data: bytes) -> Checkpoint:
-        """Decode any supported version into a modern Checkpoint."""
+        """Decode raw control-file bytes to a :class:`Checkpoint` using the known codec version."""
         if not data:
             raise ControlFileError("checkpoint file is empty")
-
-        # 1. Probe for Binary Magic
-        if data.startswith(b"HAUL"):
-            if len(data) < _MIN_BINARY_SIZE:
-                raise ControlFileError("binary header truncated")
-            version = data[4]
-        # 2. Probe for JSON (Legacy V3)
-        elif data.startswith(b"{"):
-            version = V3_JSON
-        else:
+        if not data.startswith(b"HAUL"):
             raise ControlFileError("unrecognized checkpoint format")
-
+        if len(data) < _MIN_BINARY_SIZE:
+            raise ControlFileError("binary header truncated")
+        version = data[4]
         codec = self._codecs.get(version)
-        if not codec:
+        if codec is None:
             raise ControlFileError(f"unsupported checkpoint version: {version}")
-
         return codec.decode(data)
 
     def dump(self, cp: Checkpoint) -> bytes:
-        """Serialize Checkpoint using the codec matching its version."""
-        # Ensure we always write the latest version
+        """Serialize a :class:`Checkpoint` to the wire format of :data:`LATEST_VERSION`."""
         if cp.version != LATEST_VERSION:
             cp = Checkpoint(
                 version=LATEST_VERSION,
@@ -299,19 +245,16 @@ class CheckpointRegistry:
                 block_size=cp.block_size,
                 hashes=cp.hashes,
                 tail_hash=cp.tail_hash,
-                resource_length=cp.resource_length,
+                reported_length=cp.reported_length,
             )
-
         codec = self._codecs.get(cp.version)
-        if not codec:
+        if codec is None:
             raise ControlFileError(f"no codec registered for version {cp.version}")
         return codec.encode(cp)
 
 
-# Global stateless registry instance
 registry: Final = CheckpointRegistry(
     {
-        V3_JSON: V3LegacyCodec(),
-        V4_BINARY: V4BinaryCodec(),
+        V1_BINARY: V1BinaryCodec(),
     }
 )

--- a/src/pyhaul/engine.py
+++ b/src/pyhaul/engine.py
@@ -7,7 +7,9 @@ One range, one session, one part file.  The caller borrows a
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
+from collections.abc import Callable
 from pathlib import Path
 
 from pyhaul._engine_common import (
@@ -27,6 +29,8 @@ from pyhaul._types import CompleteHaul, HaulState
 from pyhaul.transport.errors import TransportError
 from pyhaul.transport.protocols import TransportSession
 
+logger = logging.getLogger(__name__)
+
 
 def haul(
     url: str,
@@ -36,6 +40,7 @@ def haul(
     state: HaulState | None = None,
     chunk_size: int = DEFAULT_CHUNK,
     flush_every: int = DEFAULT_FLUSH,
+    on_progress: Callable[[HaulState], None] | None = None,
 ) -> CompleteHaul:
     """Download a single byte range to *dest*, resumably.
 
@@ -49,6 +54,9 @@ def haul(
     *state*, when provided, is a :class:`HaulState` updated in-place
     throughout the download — always accurate regardless of how the
     function exits.
+
+    *on_progress*, if set, is called after each chunk is written with the
+    current *state* (synchronous; keep it fast — e.g. progress UI, metrics).
 
     Returns :class:`CompleteHaul` on success.  Raises
     :class:`PartialHaulError` when the stream ends before all bytes
@@ -69,10 +77,16 @@ def haul(
                 return action
 
             plan = action
+            logger.debug(
+                "Beginning response body stream",
+                extra={"pyhaul_part_path": str(prep.part_path)},
+            )
             fd = open_part_file(plan, prep.part_path)
             try:
                 for chunk in resp.iter_raw_bytes(chunk_size=chunk_size):
                     write_chunk(fd, chunk, plan, prep, state, flush_every)
+                    if on_progress is not None:
+                        on_progress(state)
                 datasync(fd)
             except TransportError:
                 flush_dirty(fd, plan, prep)

--- a/tests/test_async_engine.py
+++ b/tests/test_async_engine.py
@@ -137,6 +137,33 @@ class TestAsyncFresh206KnownTotal:
         assert not ctrl_path_for(dest.with_suffix(dest.suffix + ".part")).exists()
 
     @pytest.mark.anyio
+    async def test_on_progress_per_chunk(self, tmp_path: Path) -> None:
+        from pyhaul.async_engine import haul_async
+
+        body = b"Hello, async world!"
+        session = AsyncMockSession()
+        session.add_response(_make_206(body, start=0, total=len(body)))
+
+        dest = tmp_path / "out.bin"
+        state = HaulState()
+        seen: list[int] = []
+
+        def on_progress(s: HaulState) -> None:
+            seen.append(s.valid_length)
+
+        await haul_async(
+            _TEST_URL,
+            session,
+            dest=str(dest),
+            state=state,
+            chunk_size=4,
+            on_progress=on_progress,
+        )
+        assert len(seen) >= 2
+        assert seen[-1] == len(body)
+        assert state.reported_length == len(body)
+
+    @pytest.mark.anyio
     async def test_sends_range_header(self, tmp_path: Path) -> None:
         from pyhaul.async_engine import haul_async
 
@@ -214,7 +241,7 @@ class TestAsyncResume206:
                     etag=ETag('"test"'),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=10,
+                    reported_length=10,
                 )
             ),
         )
@@ -257,7 +284,7 @@ class TestAsyncResumeEtagChanged:
                     etag=ETag('"old-etag"'),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=5,
+                    reported_length=5,
                 )
             ),
         )
@@ -293,7 +320,7 @@ class TestAsyncResume416AlreadyComplete:
                     etag=ETag('"test"'),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=len(body),
+                    reported_length=len(body),
                 )
             ),
         )
@@ -339,7 +366,7 @@ class TestAsyncCrashRecovery:
                     etag=ETag('"test"'),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=len(full_body),
+                    reported_length=len(full_body),
                 )
             ),
         )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -134,6 +134,33 @@ class TestFreshDownload206KnownTotal:
         assert state.valid_length == len(body)
         assert dest.read_bytes() == body
         assert not ctrl_path_for(dest.with_suffix(dest.suffix + ".part")).exists()
+        assert state.reported_length == len(body)
+
+    def test_on_progress_per_chunk(self, tmp_path: Path) -> None:
+        from pyhaul.engine import haul
+
+        body = b"Hello, world! This is test data."
+        session = MockSession()
+        session.add_response(_make_206_response(body, start=0, total=len(body)))
+
+        dest = tmp_path / "out.bin"
+        state = HaulState()
+        seen: list[int] = []
+
+        def on_progress(s: HaulState) -> None:
+            seen.append(s.valid_length)
+
+        haul(
+            _TEST_URL,
+            session,
+            dest=str(dest),
+            state=state,
+            chunk_size=8,
+            on_progress=on_progress,
+        )
+        assert len(seen) >= 2
+        assert seen[-1] == len(body)
+        assert state.reported_length == len(body)
 
     def test_sends_range_header(self, tmp_path: Path) -> None:
         from pyhaul.engine import haul
@@ -211,7 +238,7 @@ class TestResume206:
                     etag=ETag('"test"'),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=10,
+                    reported_length=10,
                 )
             ),
         )
@@ -253,7 +280,7 @@ class TestResumeEtagChanged:
                     etag=ETag('"old-etag"'),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=5,
+                    reported_length=5,
                 )
             ),
         )
@@ -292,7 +319,7 @@ class TestResumeEtagChanged:
                     etag=ETag('"old"'),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=10,
+                    reported_length=10,
                 )
             ),
         )
@@ -330,7 +357,7 @@ class TestResume416AlreadyComplete:
                     etag=ETag('"test"'),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=len(body),
+                    reported_length=len(body),
                 )
             ),
         )
@@ -374,7 +401,7 @@ class TestResumeNoEtag:
                     etag=ETag(""),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=10,
+                    reported_length=10,
                 )
             ),
         )
@@ -414,7 +441,7 @@ class TestResume416ResourceShrank:
                     etag=ETag('"test"'),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=10,
+                    reported_length=10,
                 )
             ),
         )
@@ -455,7 +482,7 @@ class TestRestart200SizeChange:
                     etag=ETag('"old"'),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=5,
+                    reported_length=5,
                 )
             ),
         )
@@ -490,7 +517,7 @@ class TestRestart200SizeChange:
                     etag=ETag('"old"'),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=12,
+                    reported_length=12,
                 )
             ),
         )
@@ -525,7 +552,7 @@ class TestRestart200SizeChange:
                     etag=ETag('"old"'),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=20,
+                    reported_length=20,
                 )
             ),
         )
@@ -566,7 +593,7 @@ class TestCrashRecovery:
                     etag=ETag('"test"'),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
-                    resource_length=len(full_body),
+                    reported_length=len(full_body),
                 )
             ),
         )

--- a/tests/test_integrity_validation.py
+++ b/tests/test_integrity_validation.py
@@ -96,7 +96,7 @@ def test_resume_tail_corruption_detected(tmp_path: Path) -> None:
         block_size=10,
         hashes=[_get_hash(block1)],
         tail_hash=_get_hash(tail_good),  # We thought it was GOOD when we saved ctrl
-        resource_length=20,
+        reported_length=20,
     )
     write_atomic(ctrl_path, registry.dump(cp))
 

--- a/tests/test_live_torture.py
+++ b/tests/test_live_torture.py
@@ -86,7 +86,7 @@ def _write_synthetic_ctrl(http: HttpTest, *, valid_length: int, extent: int, eta
         etag=ETag(etag),
         block_size=8 * 1024 * 1024,
         hashes=[],
-        resource_length=extent,
+        reported_length=extent,
     )
     http.ctrl_path.parent.mkdir(parents=True, exist_ok=True)
     write_atomic(http.ctrl_path, registry.dump(cp))

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest
@@ -28,7 +27,7 @@ def _make_checkpoint(**overrides: object) -> Checkpoint:
         "etag": ETag('"abc123"'),
         "block_size": 8 * 1024 * 1024,
         "hashes": [],
-        "resource_length": 104857600,
+        "reported_length": 104857600,
     }
     defaults.update(overrides)
     return Checkpoint(**defaults)  # type: ignore[arg-type]
@@ -68,11 +67,11 @@ class TestRoundTrip:
         assert restored.extent is None
         assert restored == cp
 
-    def test_null_resource_length(self) -> None:
-        cp = _make_checkpoint(resource_length=None)
+    def test_null_reported_length(self) -> None:
+        cp = _make_checkpoint(reported_length=None)
         raw = registry.dump(cp)
         restored = registry.load(raw)
-        assert restored.resource_length is None
+        assert restored.reported_length is None
 
     def test_empty_etag(self) -> None:
         cp = _make_checkpoint(etag=ETag(""))
@@ -111,7 +110,7 @@ class TestDeserializeErrors:
         with pytest.raises(ControlFileError, match="empty"):
             registry.load(b"")
 
-    def test_not_binary_nor_json(self) -> None:
+    def test_unrecognized_not_haul(self) -> None:
         with pytest.raises(ControlFileError, match="unrecognized"):
             registry.load(b"INVALID")
 
@@ -122,27 +121,6 @@ class TestDeserializeErrors:
     def test_wrong_version(self) -> None:
         with pytest.raises(ControlFileError, match="unsupported"):
             registry.load(b"HAUL" + b"\xff" + b"\x00" * 32)
-
-
-class TestV3Migration:
-    def test_migrates_v3_json(self) -> None:
-        v3_data = {
-            "version": 3,
-            "start": 100,
-            "extent": 1000,
-            "valid_length": 500,
-            "etag": '"migrated"',
-            "resource_length": 1000,
-        }
-        raw = json.dumps(v3_data).encode("utf-8")
-        cp = registry.load(raw)
-
-        assert cp.version == 3
-        assert cp.start == 100
-        assert cp.valid_length == 500
-        assert cp.etag == '"migrated"'
-        assert cp.block_size == 8 * 1024 * 1024
-        assert cp.hashes == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pypi_readme.py
+++ b/tests/test_pypi_readme.py
@@ -1,0 +1,18 @@
+"""The PyPI long description must match the generator (``uv run scripts/build/pypi_readme.py``)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def test_pypi_readme_is_up_to_date() -> None:
+    root = Path(__file__).resolve().parent.parent
+    path = root / "scripts" / "build" / "pypi_readme.py"
+    spec = importlib.util.spec_from_file_location("_pypi_readme", path)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    expected = mod.generate()
+    assert (root / "docs" / "PYPI_README.md").read_text() == expected

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -150,6 +150,7 @@ def test_download_state_is_mutable() -> None:
     assert state.is_complete is False
     assert state.bytes_read == 0
     assert state.valid_length == 0
+    assert state.reported_length is None
 
     state.is_complete = True
     state.bytes_read = 100

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,8 @@ revision = 3
 requires-python = ">=3.12"
 
 [options]
-exclude-newer = "2026-04-24T22:45:22.976663Z"
-exclude-newer-span = "PT48H"
+exclude-newer = "2026-04-24T19:23:48.319434Z"
+exclude-newer-span = "PT72H"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -308,6 +308,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
     { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
     { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "check-jsonschema"
+version = "0.37.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "jsonschema" },
+    { name = "regress" },
+    { name = "requests" },
+    { name = "ruamel-yaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/d4/46468808fcda2bdb824e1f5617095a14cac60f9bcefc954fbfee55712d1b/check_jsonschema-0.37.1.tar.gz", hash = "sha256:00a2ba5cdc95006e0d07e3743f4f23d80b7f30a690706c018c83578610c2e0a0", size = 408161, upload-time = "2026-03-26T02:49:59.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/cc/bfa3f5c4b8fdc05956a9426f4d7a9a85c6d6d68c8096722f612bf4db5d08/check_jsonschema-0.37.1-py3-none-any.whl", hash = "sha256:cf672ef4ccd62f9512ac40d28dde135108799ee8d749095ac72b62ecdb796d2e", size = 392983, upload-time = "2026-03-26T02:49:57.808Z" },
 ]
 
 [[package]]
@@ -1421,6 +1437,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyclean"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0d/7690e519b66101c41c114e2ddbf144f9b4ff6ea938fb199c09ed958f3970/pyclean-3.6.0.tar.gz", hash = "sha256:a46c179be187999d50d2d3362b2c94856e60f77de32ca7ec2db4eeb16bc39199", size = 27000, upload-time = "2026-03-30T17:34:30.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/2a/1797004bb000db555bd45e38550b3ca10699f87e22a78e6753882e0ac2cf/pyclean-3.6.0-py3-none-any.whl", hash = "sha256:3e5f9c83f2472df5bdafa78ed533bd38690756e0a7b3b6f11c8b29c9affc728b", size = 27750, upload-time = "2026-03-30T17:34:29.034Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1544,7 +1569,7 @@ wheels = [
 
 [[package]]
 name = "pyhaul"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1565,6 +1590,17 @@ urllib3 = [
 ]
 
 [package.dev-dependencies]
+compat-all = [
+    { name = "aiohttp" },
+    { name = "httpx" },
+    { name = "niquests" },
+    { name = "requests" },
+    { name = "types-requests" },
+    { name = "urllib3" },
+]
+dev = [
+    { name = "pyclean" },
+]
 lint = [
     { name = "codespell" },
     { name = "interrogate" },
@@ -1577,6 +1613,12 @@ lint = [
     { name = "tenacity" },
     { name = "ty" },
     { name = "validate-pyproject", extra = ["all"] },
+]
+maintainer = [
+    { name = "check-jsonschema" },
+    { name = "pyclean" },
+    { name = "rumdl" },
+    { name = "zizmor" },
 ]
 test = [
     { name = "aiohttp" },
@@ -1602,27 +1644,42 @@ requires-dist = [
 provides-extras = ["niquests", "requests", "httpx", "urllib3", "aiohttp"]
 
 [package.metadata.requires-dev]
+compat-all = [
+    { name = "aiohttp", specifier = ">=3.10" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "niquests", specifier = ">=3.14" },
+    { name = "requests", specifier = ">=2.32" },
+    { name = "types-requests", specifier = ">=2.33.0.20260408" },
+    { name = "urllib3", specifier = ">=2.0" },
+]
+dev = [{ name = "pyclean", specifier = ">=3.6.0" }]
 lint = [
-    { name = "codespell", specifier = ">=2.4" },
-    { name = "interrogate", specifier = ">=1.7" },
-    { name = "markdown-it-py", specifier = ">=4,<5" },
-    { name = "mypy", specifier = ">=1.13,<1.20" },
-    { name = "pre-commit", specifier = ">=4" },
-    { name = "pyright", specifier = ">=1.1.400" },
-    { name = "ruff", specifier = ">=0.15" },
-    { name = "semgrep", specifier = ">=1" },
-    { name = "tenacity", specifier = ">=9" },
-    { name = "ty", specifier = ">=0.0.1" },
+    { name = "codespell", specifier = ">=2.4.2" },
+    { name = "interrogate", specifier = ">=1.7.0" },
+    { name = "markdown-it-py", specifier = ">=4.0.0,<5" },
+    { name = "mypy", specifier = ">=1.19.1,<1.20" },
+    { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pyright", specifier = ">=1.1.408" },
+    { name = "ruff", specifier = ">=0.15.11" },
+    { name = "semgrep", specifier = ">=1.160.0" },
+    { name = "tenacity", specifier = ">=9.1.4" },
+    { name = "ty", specifier = ">=0.0.31" },
     { name = "validate-pyproject", extras = ["all"], specifier = ">=0.25" },
+]
+maintainer = [
+    { name = "check-jsonschema", specifier = ">=0.37.1" },
+    { name = "pyclean", specifier = ">=3.6.0" },
+    { name = "rumdl", specifier = ">=0.1.76" },
+    { name = "zizmor", specifier = ">=1.24.1" },
 ]
 test = [
     { name = "aiohttp", specifier = ">=3.10" },
-    { name = "anyio", specifier = ">=4" },
+    { name = "anyio", specifier = ">=4.13.0" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "hypothesis", specifier = ">=6" },
+    { name = "hypothesis", specifier = ">=6.152.1" },
     { name = "niquests", specifier = ">=3.14" },
-    { name = "pytest", specifier = ">=8" },
-    { name = "pytest-cov", specifier = ">=6" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "requests", specifier = ">=2.32" },
     { name = "types-requests", specifier = ">=2.33.0.20260408" },
     { name = "urllib3", specifier = ">=2.0" },
@@ -1852,6 +1909,82 @@ wheels = [
 ]
 
 [[package]]
+name = "regress"
+version = "2025.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/bf/faa406189856f9b566fa1c42d173188d3e86cd5116484a663922365e0004/regress-2025.10.1.tar.gz", hash = "sha256:dcc0a8af0cdbc3d6e0d4725f113335d0a5ffbba86ae3ca18d2b5b352c5f2c8ed", size = 11567, upload-time = "2025-10-09T07:09:48.397Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/82/68b78d093656628ded54d3e947024058f4c86f18d195174b48d370e468fd/regress-2025.10.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:45695cd7ddc6a919863f243a09a9e737257f958c0d2af0e71e349c9d0f3048ad", size = 445523, upload-time = "2025-10-09T07:08:01.16Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/aa/9c42061860892def750a5f5eb0a1894999db370f441a73a52b8b22ce8ea0/regress-2025.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:63503a8f601a10e5d9d72ea6efb415a2838a4766736775322578ce5fe18cb233", size = 434820, upload-time = "2025-10-09T07:08:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/4d/e460b2a8d2fe5bfe03658b0fa7b34fb2a4f38fe699b7d818838950b0377c/regress-2025.10.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28941c80252119ef051ad67195fa8d155a0c8dc9ecb801786d94eeea6738e4c3", size = 514909, upload-time = "2025-10-09T07:08:03.696Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e2/fa4fa358b4958fc9bcdd4037e04af26878a2dadd2be6fd21e8d78ecf0ea7/regress-2025.10.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6d26daee7d46905c8d4232f44c39ea788f10d39c166735177f603783b4ace4e8", size = 497159, upload-time = "2025-10-09T07:08:05.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6a/5f084ab9ceade680d3a55cc195fd8aa2f458e1e7b310ba79a937e31a8511/regress-2025.10.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0599f9cb12722300b6d4fcd6bd9b2be5bf233bc567c3ca503d8e392de23798a", size = 674601, upload-time = "2025-10-09T07:08:05.946Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/87f041edee9ecd50867789f053efa4888eefaab6d5c3996d6b8257dfd18b/regress-2025.10.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:46b92e1ec6092e6e989e4ad5f52f0a358e88355f70cf4dba9abce84f3cd513cf", size = 575664, upload-time = "2025-10-09T07:08:06.942Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/66/312bd179376c6cf9aab285a0c709eb3241c649a1d7ec256d34c4e7a453e7/regress-2025.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ac0e197c7f1b5ffca42341518b6a03e2ea3cdd66516af9278492d2d2bfc9ce2", size = 508055, upload-time = "2025-10-09T07:08:07.91Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/c69c6fb053de81c8f0f5d702706c4237bd021c67be977ba03f770db2579f/regress-2025.10.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05e6c68021dff89fee7bcdab25e0819cff4c7f0761dc41f0fb609b0e9ebb6272", size = 520794, upload-time = "2025-10-09T07:08:08.973Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/47/66845b8f71a3cbdc545a324bf2083fbc84fee728690f561dd85ba9dedb25/regress-2025.10.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:39600db4e404155168d6f75c3dbb2ae03ef3e288b4a57c7a6562a1144bf07682", size = 695537, upload-time = "2025-10-09T07:08:09.946Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/c389c1b0ab16d33755f3b58c34ba92c9991e1fca31e5e3e608baa04b2f47/regress-2025.10.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d48e91d14a366570685f76adaf9d108e3abc5522572e7e1d0d78c3cc3ebf0833", size = 695148, upload-time = "2025-10-09T07:08:11.668Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/ae94eb4dd93a18be022fa72a88ca73f5f3cfd78f077afdb40b66e2139db9/regress-2025.10.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ce4e38ada2a39159d8a2523084e2b5ed94b3f7f7b196ba6b99c2d6c4ff634a87", size = 690997, upload-time = "2025-10-09T07:08:12.812Z" },
+    { url = "https://files.pythonhosted.org/packages/42/1f/669280d98640568d1012e1b77178eb75b3ceb468c9bc50058529a90f42f5/regress-2025.10.1-cp312-cp312-win32.whl", hash = "sha256:c35c8cd42900d9195e5bf48d701dda28c204854fba7cc27d18f309745f57b8b5", size = 282521, upload-time = "2025-10-09T07:08:13.922Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/d77a57e89ace8fd0b6acb124dfefd536e8e696103cba21956050f09b69a4/regress-2025.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:089b6c5f0965962e8046493e5a1222a24e88d6f235fa8fe2424ec869e6ff613c", size = 301556, upload-time = "2025-10-09T07:08:14.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ce/a0e08ff0f36d6106152b33148a087c77f6cbb649863440447b1cdfd393d1/regress-2025.10.1-cp312-cp312-win_arm64.whl", hash = "sha256:469b03b1deffb6d20ea4f95aa44ef0e0e5a9b47d56f709276b06a96338b570a0", size = 288571, upload-time = "2025-10-09T07:08:15.772Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/bd/f7ff13577c688efec36488554489635c135ab7c2b3652c00aaa3d74bd761/regress-2025.10.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9100da34f69e18ad6d545f5d74f8ee729e42ce200a73752dd6d94f8a373d0e71", size = 445469, upload-time = "2025-10-09T07:08:16.825Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3d/e8fc72e7424c168dfc4cdf3a864f189f6d3afbb6e3ed66455774d1f5e2ba/regress-2025.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9e25096697b034848d8fc7910cdb38b7abc2bd2d7ade8767893359918ed4efd0", size = 434712, upload-time = "2025-10-09T07:08:17.817Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d0/a18cc39008765d2b964bc2eba423416545d97b4f2623b99549c5e97e4d37/regress-2025.10.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c4c40a8c9f3e0119d2384a52b55dcc770461e1ead6ae7b41314999223116a15", size = 514752, upload-time = "2025-10-09T07:08:19.148Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/11/57e64ba417867b39ad9ca55feaea80d3176735dba36e6a92ff21b8224fcb/regress-2025.10.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25d8518285aa3ce67ddbede90a1a9ca6a5d23a1b8275dd5a9722af0c64b37b2a", size = 497412, upload-time = "2025-10-09T07:08:20.448Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6c/2fd3d3877c1957408548f7a380580f0b64ef8aff69f7fc2cc182a79b0b0b/regress-2025.10.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8051fac3696730bb84d7675c62c7073792a0e105233d4f8e1055f2cab9b04fce", size = 676998, upload-time = "2025-10-09T07:08:21.881Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/54/acde146473453f3acb5dd29e5be0fb627d87ad020ec5674ee133cde24261/regress-2025.10.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8e337ce3b150ca0ff599b1150b995ff6a2e32b5940e17ac3f30a29133960709e", size = 576129, upload-time = "2025-10-09T07:08:23.354Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b0/8007436b33496ec8f10d7b7a67a7a669569c82fc2a182d4f928ab4fd11da/regress-2025.10.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:290a15652c3fafe387db02061d4ed9a100804ed5a162d069b5a0ac28b5df162a", size = 507510, upload-time = "2025-10-09T07:08:24.34Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9e/6ac6cd1de7e34e34cb492df627847de0d01cee982c7dd7d100e67cf1aa93/regress-2025.10.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b4bc2008b59e5124c1672d7fd9f203e5d4a4ff88ebaf4666e3281141e2d8db20", size = 520595, upload-time = "2025-10-09T07:08:25.35Z" },
+    { url = "https://files.pythonhosted.org/packages/11/26/35556d1dd6f64122a16166db7651d1a5804edebea9835cbcd452d9b7c2ff/regress-2025.10.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:56ef2f8ef9a102a7d42cbbc2f3c0c5e1b186bd8eaa78d564da566b0bf20653dc", size = 695584, upload-time = "2025-10-09T07:08:26.52Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/33/07650dfc042b55270fc269276112c592d458cdfb8d31c85447ff743dcf10/regress-2025.10.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0680ac0b0a0058acb55b64aa56956732cf56b0baa84ea95e3fa124ab16da58aa", size = 695277, upload-time = "2025-10-09T07:08:27.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6b/80f446103df39fc1ce6e271e7c274687bb830402de23e68795ba2ab13214/regress-2025.10.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47c03bfd853651241fc11436fb14ef7c9b312bb9a9c2828aa5c93943e945f1ef", size = 690951, upload-time = "2025-10-09T07:08:29.295Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/10/43cd990934ddb2be3318380fa380f7ca19e0eda0c30793b73e8ab8839367/regress-2025.10.1-cp313-cp313-win32.whl", hash = "sha256:3d12e6a834ed5f6d9dc7e86ea8fd77d37bb13900129930151d87c3261c3a799e", size = 282592, upload-time = "2025-10-09T07:08:30.695Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/22/4855af0447c98793d3a406ddf42680736e700b8c78336d6199dff9a5fd1b/regress-2025.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:ee3b7325ea849097d674020c72b2e6deb8f1018f085a7ecbd22831cd217b7f80", size = 301551, upload-time = "2025-10-09T07:08:31.715Z" },
+    { url = "https://files.pythonhosted.org/packages/82/99/cd16dce5d1cb98970a8d7c577529e5890d938b54ade223d532fad0343221/regress-2025.10.1-cp313-cp313-win_arm64.whl", hash = "sha256:e5f35e04fe6382c236d60c98b3f0a4a22dea75398b99c9c9bf3fb9d386cd7ebb", size = 288909, upload-time = "2025-10-09T07:08:32.605Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/32/35dbbdff29174dcc253bb00b2a0d2aaf3f47a2b1d174ab4ab828feca63f1/regress-2025.10.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:0ee12c4e1c4e6e3609f41dd58065bc241945e912772f7320238d6544f0745950", size = 444440, upload-time = "2025-10-09T07:08:33.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1b/d97cf19b3de5ff8d78d03e0c470af48f7e8b6814b197014fda3f8a3aaca5/regress-2025.10.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:389c2278848cbfed81753a04ce8ea6c037271179cb9ef4decac7d3c65ae3330b", size = 434626, upload-time = "2025-10-09T07:08:34.75Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f1/c0900448a4fd6248cd05c04c83aebb31f22ba3886965a5667f6ac4edc2b0/regress-2025.10.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf743b00cac20f8e8d271f275df7bc192ebb4faa7aee8fe98484df338786dec6", size = 514470, upload-time = "2025-10-09T07:08:35.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a1/6346a314230af2859d2f0af5c4534ee497b9b13983ee06489652d7e1895b/regress-2025.10.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5541da1f581377bc20d2f77e017453aa8f2c2f4bfe7679dee00e139ec700abe8", size = 497546, upload-time = "2025-10-09T07:08:36.739Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ff/09605137dff09594c9e12ce555a80d8405a6ad76faa1db702bfba57468d0/regress-2025.10.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a67216efa72bb27db170f637d67eb9acdc167da5d617163b057803de7aed1e6d", size = 676318, upload-time = "2025-10-09T07:08:37.72Z" },
+    { url = "https://files.pythonhosted.org/packages/26/37/4a65635c18844d687f9ad5bdd79b72fac8d15b131264616d6b1bb52614c2/regress-2025.10.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fb61e653a325aea4681cf7b96ba9bbabc1aeb3f3d8fe877a07800024907398b9", size = 576190, upload-time = "2025-10-09T07:08:38.782Z" },
+    { url = "https://files.pythonhosted.org/packages/93/87/90a0a77a0416d7e3255e606f848021949b2f53ca18c9e4e240edb42e0929/regress-2025.10.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2a0a7da1d42fdff8068ab976a66beea572621514a130b37592489ae134a0e27", size = 507768, upload-time = "2025-10-09T07:08:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/82c8147027f0012dd7e743267d60dcf4218b2e061825b89cddddaa7fbe49/regress-2025.10.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:337ef62f785dc6e05c4a09be7a902980cf4d4f15346f4eca9eaf02745485440c", size = 520555, upload-time = "2025-10-09T07:08:40.801Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ce/5dd5dda048173b644a475ae9f4643733b31c3543e861569af4257c60d32a/regress-2025.10.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:aaf5d102e05b109dde13363e705969b3ffdbbfeb880270187eed0871e75f0c8f", size = 695587, upload-time = "2025-10-09T07:08:42.136Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/08/7f6615d8ce3088feb82843ff4d48191600602d624021dbef797d274a043d/regress-2025.10.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:adf331c8938e0d8705fc5d05d08fab09c11cb4bcdf8a64fa21902972c4cd38f4", size = 694933, upload-time = "2025-10-09T07:08:43.171Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/94524b996745f892b30dec6e770701956f7125459c6a6b2c075af4b8f0a6/regress-2025.10.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:287f86b5c0bf3bc9c0abd45bf6745ba9c6a5624c3132b07631bac4403b45143f", size = 691029, upload-time = "2025-10-09T07:08:44.369Z" },
+    { url = "https://files.pythonhosted.org/packages/64/e1/612c3b8afa448747e9133a95b1e18d0ee8f3f5e930f7048d1af03976f883/regress-2025.10.1-cp313-cp313t-win32.whl", hash = "sha256:877e05e7c570ee1e077e8b587cca8a318b7675f3c94c6c4e25d0d145abf7c0b6", size = 282136, upload-time = "2025-10-09T07:08:45.477Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1d/9d5a476a6b16a41e724e864afb834947323bfa4b309978dbdc2bf8dbdb02/regress-2025.10.1-cp313-cp313t-win_amd64.whl", hash = "sha256:97307f87b128389d8b3f385c8e431fc318263281d1a1c0394606bc813aea05fc", size = 301674, upload-time = "2025-10-09T07:08:46.513Z" },
+    { url = "https://files.pythonhosted.org/packages/63/a0/49e86facc015003db16ff9e6ce5086e843b45a19f4e0e34ce59e6d6c2d81/regress-2025.10.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:56123dbe783a2bab04d1a1850605c483d40f36196bc52d249aa245d06f866f78", size = 444793, upload-time = "2025-10-09T07:08:47.867Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3f/2873d64a063d33f721ffa66f2543ef5a5482a0e8d69d700e28e8e40e1ae6/regress-2025.10.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8405a31f0a1475e1c9aa20c4d6e1465ef2f7259581c018a2e273083494ca9a61", size = 434881, upload-time = "2025-10-09T07:08:49.192Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/7179ca674432677db0060c49fc79a1816b7585e5ba10cfc546251a362d35/regress-2025.10.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12430b2c7263a7b359d30dd0f2b179426d489df30da78cd21023376eb2fe2682", size = 514673, upload-time = "2025-10-09T07:08:50.203Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/de/2f35d611ee0223001c2b3ffe80ae4509dc8d082171d60046db179fada84e/regress-2025.10.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7ecba827aff7f951db40be777c32608a1b16bbeb7f02fcc97a2e9fc6702641f", size = 498108, upload-time = "2025-10-09T07:08:51.304Z" },
+    { url = "https://files.pythonhosted.org/packages/97/82/6f1762b94810e55ab179a4ec2f804f5b8af152c3fb8d348fee7642437e29/regress-2025.10.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:293be370961c6887efb82e466a15523ff24a702d444f44917ce318b222ffd229", size = 676532, upload-time = "2025-10-09T07:08:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/06/46/c24aa9299b9706cf39422b48ba6cbba20e2826b3850f3d2a1b6d2865b1b1/regress-2025.10.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:783b9c50760aab988e4d60dcb7c54eba3fe730d80f9a877f1dc52d14263f86b1", size = 576455, upload-time = "2025-10-09T07:08:53.637Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a7/e13517b6388d058406e69387045797d3b4358c44f8dd37a457f4714123eb/regress-2025.10.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ed3b4d0df960aeccb685f8de5001c19f426f1ab09fde715e5abdbf9c59b26a", size = 506859, upload-time = "2025-10-09T07:08:54.557Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a5/52b57c409586809402595f1b7938826cc84fb9983be1fa7bbdce14026613/regress-2025.10.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:08e99c44e4c3860352400af96b25a4ebb673c16d53c6367153631ec77d5130b8", size = 520546, upload-time = "2025-10-09T07:08:55.56Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/5f/e46311b2452d0419aeca10df5c16ae554f82ba8d21a9cc854ed225ea4a49/regress-2025.10.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6b52096ecbf39f50756e51efa9286f47c598572f6b8bb2119f855de817f38b8e", size = 695829, upload-time = "2025-10-09T07:08:56.543Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6f/fd52382dcd315594cd5ec74bb436a5ca6a6376e5f205b9711c1e2abc4e4c/regress-2025.10.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:b99a73cfbdc5d99681aeb3aeaa2d88369023c96648cc785433d6a92c8d3a8394", size = 695324, upload-time = "2025-10-09T07:08:57.572Z" },
+    { url = "https://files.pythonhosted.org/packages/75/88/61ad735f401d0b9b043c52e4cea95bff10584894351c878eeb52e34e01e1/regress-2025.10.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:05d02b4d7179b85acf28d7329a488901d6baef5f5b337dcd52f53ea0ff980bc3", size = 691245, upload-time = "2025-10-09T07:08:58.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/26f42441c7d3aaa68af23520d298475e19338bf087bae2d687d911869036/regress-2025.10.1-cp314-cp314-win32.whl", hash = "sha256:e7cc153fabb47b6f8dfc2903186934e07aa57ee1debe9b3569ac4779b43708ae", size = 282612, upload-time = "2025-10-09T07:08:59.898Z" },
+    { url = "https://files.pythonhosted.org/packages/66/18/ecbc4b30960988fde96f0e36fdd59d687af734befc013a03395c519ae46b/regress-2025.10.1-cp314-cp314-win_amd64.whl", hash = "sha256:102c4627f026db8d361ab61155e0f1093176555d60ddb1cc4c9b6f5bbe255c1f", size = 301416, upload-time = "2025-10-09T07:09:00.805Z" },
+    { url = "https://files.pythonhosted.org/packages/53/05/0f5b750f65428b00e8b90af33935f667dad267ea0e9493aef993e307b60b/regress-2025.10.1-cp314-cp314-win_arm64.whl", hash = "sha256:e5c441a6017a5a29bb38c573892d882485cc26937cb1ee12da8593723bf6c041", size = 288347, upload-time = "2025-10-09T07:09:02.07Z" },
+    { url = "https://files.pythonhosted.org/packages/88/43/33a2ec3342919ff5516e4eec66ae01fd3dea8ff51c86f8746a8f34211dc9/regress-2025.10.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:77d63b338c2a4e56b4f05632d3fd94061ad47ee2b272b158b9c2e09545a4c6bb", size = 444092, upload-time = "2025-10-09T07:09:03.088Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/30/2f5d12fa93215fe914eaa0ce3bb7f184d9b4460ba9cf4bb6ad17bd40418a/regress-2025.10.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:722c408a3bc92b4904005e68244c28fa6df943290df8d670faf349414c86aabb", size = 434309, upload-time = "2025-10-09T07:09:04.503Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/19/6c76d2a5617c7980c752ea3b6152f070a9c708e789032e3219377743556a/regress-2025.10.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3afe24e6474f5dbc448f865641c29bcbed4eb3b87ac9eb0e6755c4eff4f7111", size = 514890, upload-time = "2025-10-09T07:09:05.488Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/d3/04cede3329ce180477856b56875bdf5c51936584fe1e8717f2f5b80ce5b9/regress-2025.10.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9fdbbea49bf2fe65f7272b0316e1343aff1ccbb85b58fab325778c416d648ed9", size = 496277, upload-time = "2025-10-09T07:09:10.062Z" },
+    { url = "https://files.pythonhosted.org/packages/16/9c/2954a87ea2bd6c75506233242a7b0a1e68553b07772b72d6acc7b08e0f9a/regress-2025.10.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6d451a88292c5a93f57cf754c71b3aa8b570ed159f9fd481554948c467e6105d", size = 677710, upload-time = "2025-10-09T07:09:11.054Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/47/199000108d39b40339532d2e6d9e0188cb747da8478cd697cf57ab7d9411/regress-2025.10.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a97649f21c875b7e95e10a59f0f487a518735f51a7aec7fc95fb2c3d9a3914d5", size = 575255, upload-time = "2025-10-09T07:09:12.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/49/84e96203933feffb1e77f6553e82684501a34e144f64c50113f7c2228fde/regress-2025.10.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a542e38c8bb95f618674a5d2d248f1010547d7ff2e46a6cf4fa4b851459ba440", size = 507535, upload-time = "2025-10-09T07:09:13.408Z" },
+    { url = "https://files.pythonhosted.org/packages/47/0d/e368ef1b8d3d19633d49cf35c48154fd382da643246c3ad58d63a1053f45/regress-2025.10.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:933561ea90b2ac9a826e956a994b8a66635cd96467374281da992ceea8b0de4c", size = 520011, upload-time = "2025-10-09T07:09:14.546Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/25/6a1c13a7a18444cfedcef80a5727d3feae2055214d228e7847a647431e77/regress-2025.10.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b6b5aa9f9408fdf260c73071282a28d29efbb4c30a4b95ab29863bea31987621", size = 695675, upload-time = "2025-10-09T07:09:15.983Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7c/2000eadccfc762da29004b192f1c15e2d026d0b6dd5fb0ff3f5f06cfd216/regress-2025.10.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:afee501f000666afe18531132edcaf0dc0178dd591cccf5b9596563e7456c118", size = 694358, upload-time = "2025-10-09T07:09:16.98Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5a/5743b01774c8c438811e357d79fdce4be7729a59e72f28f4b2df0379784e/regress-2025.10.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4d0bf23a6d996655ed88c822bb0123cc2e92a1df95079ce7408552c35ec05d47", size = 691223, upload-time = "2025-10-09T07:09:18.467Z" },
+    { url = "https://files.pythonhosted.org/packages/47/03/8f99f04fa8fa307c343285f8630537ad493a78754c273de7427c084dc5b1/regress-2025.10.1-cp314-cp314t-win32.whl", hash = "sha256:adaa80c97927d623ff72b920bcc637568f124eabe84559c7927a91253ff55d5e", size = 281997, upload-time = "2025-10-09T07:09:19.51Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/7e/e65462387ffd8f67ffea40482d55655a89b9088f258def3824007e6b7c74/regress-2025.10.1-cp314-cp314t-win_amd64.whl", hash = "sha256:6553c8ba57fa92ab3e9ef5c811d6214c80131bba06496bd5920e6e5a3d53ca8e", size = 301375, upload-time = "2025-10-09T07:09:20.431Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2029,6 +2162,21 @@ wheels = [
 ]
 
 [[package]]
+name = "rumdl"
+version = "0.1.76"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/34/8fd64365b8f1757e5447aa5171124db927d94cf671cc7f8bd5aaf0b9ab01/rumdl-0.1.76.tar.gz", hash = "sha256:6b939c3e44485d6457f7543b09ad04be91a7326236fb40e2ad76940e5194d47b", size = 2332119, upload-time = "2026-04-19T20:56:54.723Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/5b/455cfc75cd74ed1d8008e32ea7eec85030806874d1f6e68a940bf972a5b2/rumdl-0.1.76-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ec7ff28ce9dc791145f7c5b76fb9b0150216689a7dfad729af465a1f4fc5e88c", size = 5286374, upload-time = "2026-04-19T20:56:47.754Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/81/757a4318cdb793dbc428b69bd27dba2c9d42f2ab573f2b6ca608a4083cd8/rumdl-0.1.76-py3-none-macosx_11_0_arm64.whl", hash = "sha256:26771c93f1935018da229f694afc246ca7d202786f40b7fb3fd42b387457dc7d", size = 4908118, upload-time = "2026-04-19T20:56:42.76Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6c/4f1771fc16a13407bf02e5f3ae52a7f4d9a437e9e1e85d0c5f44a3846a4c/rumdl-0.1.76-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:b640fe62d6fcc791c4cb3c87e3ab1d6a31da479c57a51cfe49a2ba15e9cb39b0", size = 5125708, upload-time = "2026-04-19T20:56:44.974Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/20/3ae2bd93f269e381e111d5285ffe5ab6685d04bcf8c407621128b532722c/rumdl-0.1.76-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:350e27bdba5cde776435b0384fbab6eb89fd8e259e9a683483ed9694ebf2e490", size = 5524102, upload-time = "2026-04-19T20:56:51.129Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5b/b7d2b74911d28630f139aee3b062f968f73f37288bd0aa879abcbe440624/rumdl-0.1.76-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7904a7376c1242893b290a4bbf163aaeb8b858a9dcdbed920d342f4d428b13e8", size = 5128994, upload-time = "2026-04-19T20:56:46.316Z" },
+    { url = "https://files.pythonhosted.org/packages/40/91/2c9ac466eccff0f6761838db6f6a236841b432c220d251d458da3221d4cd/rumdl-0.1.76-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:058ac91dcd87e398100791e4c08ab8545321cc2e4030b7f8080f21fe6c97b4ba", size = 5517679, upload-time = "2026-04-19T20:56:52.916Z" },
+    { url = "https://files.pythonhosted.org/packages/97/22/93ba093b35c57eac2f7fed40af18694ff7718580e3a5a7585f97ba56bf22/rumdl-0.1.76-py3-none-win_amd64.whl", hash = "sha256:d629cf0717d9526f6058715ee66826cf8296a04a020b73733d6f00270469df1c", size = 5587417, upload-time = "2026-04-19T20:56:49.391Z" },
+]
+
+[[package]]
 name = "semantic-version"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2039,7 +2187,7 @@ wheels = [
 
 [[package]]
 name = "semgrep"
-version = "1.161.0"
+version = "1.160.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -2070,15 +2218,15 @@ dependencies = [
     { name = "urllib3" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/de/37c8b9d716d6d1e8a494ca960396a37b49fc79b593437d603489ffec58c8/semgrep-1.161.0.tar.gz", hash = "sha256:4f078397b7f2d4a88dbe803cb4b1128266339e3a5797208695cf2aee444d7b83", size = 55346055, upload-time = "2026-04-22T21:08:10.213Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/ce/52879ba3af7e957dbe67415b4fe1732304ad8db8f62410198306ffe2dedd/semgrep-1.160.0.tar.gz", hash = "sha256:ae783216a6b9df8ad131bdd003c9b21c8a1c3afb5205752b50e6665295b693fd", size = 55271872, upload-time = "2026-04-20T17:41:18.723Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/47/2c21a67bdb44786a0ff5cd41a91968c827edef28e988a54e33b45fa601ad/semgrep-1.161.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-macosx_10_14_x86_64.whl", hash = "sha256:345068df665f3b48742ae9ce69679f5919f2baed5791892ee514f13a909f5964", size = 44680267, upload-time = "2026-04-22T21:07:39.991Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/ff/b7a91b66b31bcc681b75068fe7d57c859d918dcba681b1537ac011666c50/semgrep-1.161.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-macosx_11_0_arm64.whl", hash = "sha256:1f9d43a97f78c8ca9bc2f0eb9486b70fae2106dbd802f7a52bb1cb9d58f9f3c8", size = 48602046, upload-time = "2026-04-22T21:07:43.542Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/08/3382aab9139ad344dd85b90f54b3fe92c1de8c0b41795356bdfda4e75e62/semgrep-1.161.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-manylinux_2_35_aarch64.whl", hash = "sha256:c8316729d54882dede14d7166f4cdaf6174927b05895d12888ae3a0f4791c785", size = 77963546, upload-time = "2026-04-22T21:07:47.762Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/bf/573042ea49590bff369dc96ca687068dc90947b33a261cf19b889f4795b5/semgrep-1.161.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-manylinux_2_35_x86_64.whl", hash = "sha256:8a82257d654348f94250f410701f1124dc70a0c4338461acc5ee713e101b0d9d", size = 76204940, upload-time = "2026-04-22T21:07:52.203Z" },
-    { url = "https://files.pythonhosted.org/packages/28/95/0c86c0341b3b104aeea1e814ed9d874605486c11a92d8c613266969d9a89/semgrep-1.161.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-musllinux_1_2_aarch64.whl", hash = "sha256:ae2d56f0c14910c9ac15d7de2ff084994d249b4b20c972931bb4dfa11e78f4d2", size = 78411785, upload-time = "2026-04-22T21:07:56.764Z" },
-    { url = "https://files.pythonhosted.org/packages/34/a0/ed74b68e7720298e58b1458483698091123f9b6884ac5d2754755ed68137/semgrep-1.161.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-musllinux_1_2_x86_64.whl", hash = "sha256:6583d68017890561fc93087056a565564051f498cb0637bde1af3945b755b164", size = 75949179, upload-time = "2026-04-22T21:08:01.832Z" },
-    { url = "https://files.pythonhosted.org/packages/26/54/51305a35e4b0cef706259d28ceab2e3aa5de548d290a124f1860b433aa64/semgrep-1.161.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-win_amd64.whl", hash = "sha256:bf4bc7caf27fa817f4a5a26b0875add679bc011aff70ae44aa46913e21f5a401", size = 56273247, upload-time = "2026-04-22T21:08:05.823Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ed/30ce3a8c41adbc9a001c29d5f62bf75f3997e0b97badcc1b06945ec33908/semgrep-1.160.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-macosx_10_14_x86_64.whl", hash = "sha256:14dcadfed4d022228a2a765c6dd4326c62fb1621f156f2bb9d4d769e20d1cf36", size = 44628780, upload-time = "2026-04-20T17:40:50.573Z" },
+    { url = "https://files.pythonhosted.org/packages/03/59/88ffa66b79155a90c9ab4a74dded754e50ea9f5fd024c0477256636666b0/semgrep-1.160.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-macosx_11_0_arm64.whl", hash = "sha256:594045a69a49b09a500b0f23c8bba86cfc5037a8e868ea72d563b45ec6d998a3", size = 48573109, upload-time = "2026-04-20T17:40:54.588Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/2da1ef9ce5e676e01adbfedd89425bce1066cafd7d1f5470c9dcbc8e14df/semgrep-1.160.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-manylinux_2_35_aarch64.whl", hash = "sha256:107e59f64ba6dc865ac70d481e111f480c67b4cd1ee7c5eb12f495d7f31dd815", size = 77855703, upload-time = "2026-04-20T17:40:58.164Z" },
+    { url = "https://files.pythonhosted.org/packages/db/17/1f71ccd8541b836d6509bf05a81033307b4f30a9c76695c18ee53580fc79/semgrep-1.160.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-manylinux_2_35_x86_64.whl", hash = "sha256:5f3adacbc574831854d461398bbebf087f74fe689d8a6997de1da8ea1e3fe832", size = 76087420, upload-time = "2026-04-20T17:41:01.972Z" },
+    { url = "https://files.pythonhosted.org/packages/67/44/89b9ec22e7ab5421bcf107c77fdc516702b58b04dea4ac7a2c249201bb7a/semgrep-1.160.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-musllinux_1_2_aarch64.whl", hash = "sha256:ab15c8a530f886918c77aa20af629ed9d0702f3eba8e5fed4230f7a73cc0ab69", size = 78296796, upload-time = "2026-04-20T17:41:06.086Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/e5/0167b7c1f22af3e7b9011e60d8f62caa97926f3a2e793f3815c94d8e644b/semgrep-1.160.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-musllinux_1_2_x86_64.whl", hash = "sha256:25a09464366b86a589b2e6bf08dc617f2f5f3d988aa732817c3a6cdc2cf275d0", size = 75808352, upload-time = "2026-04-20T17:41:10.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/9e/dd95884341cc464ed9f8acebc0e1f8c6313eabbe4fb417522cc09c03cdc5/semgrep-1.160.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-win_amd64.whl", hash = "sha256:d901b4cce97a941b7abd1039d7e9193f52609e6b1318bf5d2732f16271f42efa", size = 56198999, upload-time = "2026-04-20T17:41:13.611Z" },
 ]
 
 [[package]]
@@ -2154,26 +2302,26 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.32"
+version = "0.0.31"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/7e/2aa791c9ae7b8cd5024cd4122e92267f664ca954cea3def3211919fa3c1f/ty-0.0.32.tar.gz", hash = "sha256:8743174c5f920f6700a4a0c9de140109189192ba16226884cd50095b43b8a45c", size = 5522294, upload-time = "2026-04-20T19:29:01.626Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/cc/5ea5d3a72216c8c2bf77d83066dd4f3553532d0aacc03d4a8397dd9845e1/ty-0.0.31.tar.gz", hash = "sha256:4a4094292d9671caf3b510c7edf36991acd9c962bb5d97205374ffed9f541c45", size = 5516619, upload-time = "2026-04-15T15:47:59.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/eb/1075dc6a49d7acbe2584ae4d5b410c41b1f177a5adcc567e09eca4c69000/ty-0.0.32-py3-none-linux_armv6l.whl", hash = "sha256:dacbc2f6cd698d488ae7436838ff929570455bf94bfa4d9fe57a630c552aff83", size = 10902959, upload-time = "2026-04-20T19:28:31.907Z" },
-    { url = "https://files.pythonhosted.org/packages/33/d2/c35fc8bc66e98d1ee9b0f8ed319bf743e450e1f1e997574b178fab75670f/ty-0.0.32-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:914bbc4f605ce2a9e2a78982e28fae1d3359a169d141f9dc3b4c7749cd5eca81", size = 10726172, upload-time = "2026-04-20T19:28:44.765Z" },
-    { url = "https://files.pythonhosted.org/packages/96/32/c827da3ca480456fb02d8cea68a2609273b6c220fea0be9a4c8d8470b86e/ty-0.0.32-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4787ac9fe1f86b1f3133f5c6732adbe2df5668b50c679ac6e2d98cd284da812f", size = 10163701, upload-time = "2026-04-20T19:28:27.005Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/9e/2734478fbdb90c160cb2813a3916a16a2af5c1e231f87d635f6131d781fb/ty-0.0.32-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8ea0a728af99fe40dd744cba6441a2404f80b7f4bde17aa6da393810af5ea57", size = 10656220, upload-time = "2026-04-20T19:29:03.814Z" },
-    { url = "https://files.pythonhosted.org/packages/44/9f/0007da2d35e424debe7e9f86ffbc1ab7f60983cfbc5f0411324ab2de5292/ty-0.0.32-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2850561f9b018ae33d7e5bbfa0ac414d3c518513edcffe43877dc9801446b9c5", size = 10696086, upload-time = "2026-04-20T19:28:46.829Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/5e/ce5fd4ec803222ae3e69a76d2a2db2eed55e19f5b131702b9789ef45f93d/ty-0.0.32-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5fa2fb3c614349ee211d36476b49d88c5ef79a687cdb91b2872ad023b94d2f8", size = 11184800, upload-time = "2026-04-20T19:28:42.57Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/46/ebcf67a5999421331214aac51a7464db42de2be15bbe929c612a3ed0b039/ty-0.0.32-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2b89969307ab2417d41c9be8059dd79feea577234e1e10d35132f5495e0d42c6", size = 11718718, upload-time = "2026-04-20T19:28:36.433Z" },
-    { url = "https://files.pythonhosted.org/packages/18/2c/2141c86ed0ce0962b45cefb658a95e734f59759d47f20afdcd9c732910a1/ty-0.0.32-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b59868ede9b1d69a088f0d695df52a0061f95fa7baa1d5e0dc6fc9cf06e1334", size = 11346369, upload-time = "2026-04-20T19:28:48.967Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/da/ed6f772339cf29bd9a46def9d6db5084689eb574ee4d150ff704224c1ed8/ty-0.0.32-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8300caf35345498e9b9b03e550bba03cee8f5f5f8ab4c83c3b1ff1b7403b7d3a", size = 11280714, upload-time = "2026-04-20T19:28:51.516Z" },
-    { url = "https://files.pythonhosted.org/packages/da/9b/c6813987edf4816a40e0c8e408b555f97d3f267c7b3a1688c8bbdf65609c/ty-0.0.32-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:583c7094f4574b02f724db924f98b804d1387a0bd9405ecb5e078cc0f47fbcfb", size = 10638806, upload-time = "2026-04-20T19:28:29.651Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/d4/0cefcbd2ad0f3d51762ccf58e652ec7da146eb6ae34f87228f6254bbb8be/ty-0.0.32-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e44ebe1bb4143a5628bc4db67ac0dfebe14594af671e4ee66f6f2e983da56501", size = 10726106, upload-time = "2026-04-20T19:29:06.3Z" },
-    { url = "https://files.pythonhosted.org/packages/32/ad/2c8a97f91f06311f4367400f7d13534bbda2522c73c99a3e4c0757dff9b8/ty-0.0.32-py3-none-musllinux_1_2_i686.whl", hash = "sha256:06f17ada3e069cba6148342ef88e9929156beca8473e8d4f101b68f66c75643e", size = 10872951, upload-time = "2026-04-20T19:28:34.077Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/68/42293f9248106dd51875120971a5cc6ea315c2c4dcfb8e59aa063aa0af26/ty-0.0.32-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e96e60fa556cec04f15d7ea62d2ceee5982bd389233e961ab9fd42304e278175", size = 11363334, upload-time = "2026-04-20T19:28:54.036Z" },
-    { url = "https://files.pythonhosted.org/packages/df/92/be9abf4d3e589ad5023e2ea965b93e204ec856420d46adf73c5c36c04678/ty-0.0.32-py3-none-win32.whl", hash = "sha256:2ff2ebb4986b24aebcf1444db7db5ca41b36086040e95eea9f8fb851c11e805c", size = 10260689, upload-time = "2026-04-20T19:28:56.541Z" },
-    { url = "https://files.pythonhosted.org/packages/14/61/dc86acea899349d2579cb8419aecedd83dc504d7d6a10df65eef546c8300/ty-0.0.32-py3-none-win_amd64.whl", hash = "sha256:ba7284a4a954b598c1b31500352b3ec1f89bff533825592b5958848226fdc7ee", size = 11255371, upload-time = "2026-04-20T19:28:39.917Z" },
-    { url = "https://files.pythonhosted.org/packages/43/01/beffec56d71ca25b343ede63adb076456b5b3e211f1c066452a44cd120b3/ty-0.0.32-py3-none-win_arm64.whl", hash = "sha256:7e10aadbdbda989a7d567ee6a37f8b98d4d542e31e3b190a2879fd581f75d658", size = 10658087, upload-time = "2026-04-20T19:28:59.286Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/10/ea805cbbd75d5d50792551a2b383de8521eeab0c44f38c73e12819ced65e/ty-0.0.31-py3-none-linux_armv6l.whl", hash = "sha256:761651dc17ad7bc0abfc1b04b3f0e84df263ed435d34f29760b3da739ab02d35", size = 10834749, upload-time = "2026-04-15T15:48:14.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4c/fabf951850401d24d36b21bced088a366c6827e1c37dab4523afff84c4b2/ty-0.0.31-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c529922395a07231c27488f0290651e05d27d149f7e0aa807678f1f7e9c58a5e", size = 10626012, upload-time = "2026-04-15T15:48:22.554Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b0/4a5aff88d2544f19514a59c8f693d63144aa7307fe2ee5df608333ab5460/ty-0.0.31-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5f345df2b87d747859e72c2cbc9be607ea1bbc8bc93dd32fa3d03ea091cb4fee", size = 10075790, upload-time = "2026-04-15T15:47:46.959Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/73/9d4dcad12cd4e85274014f2c0510ef93f590b2a1e5148de3a9f276098dad/ty-0.0.31-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4b207eddcfbafd376132689d3435b14efcb531289cb59cd961c6a611133bd54", size = 10590286, upload-time = "2026-04-15T15:48:06.222Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/fe40adde18692359ded174ae7ddbfac056e876eb0f43b65be74fde7f6072/ty-0.0.31-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:663778b220f357067488ce68bfc52335ccbd161549776f70dcbde6bbde82f77a", size = 10623824, upload-time = "2026-04-15T15:48:12.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e8/0ffa2e09b548e6daa9ebc368d68b767dc2405ca4cbeadb7ede0e2cb21059/ty-0.0.31-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3506cfe87dfade0fb2960dd4fffd4fd8089003587b3445c0a1a295c9d83764fb", size = 11156864, upload-time = "2026-04-15T15:48:08.473Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e9/fd44c2075115d569593ee9473d7e2a38b750fd7e783421c95eb528c15df5/ty-0.0.31-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8b3f3d8492f08e81916026354c1d1599e9ddfa1241804141a74d5662fc710085", size = 11696401, upload-time = "2026-04-15T15:48:17.355Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/50/35aad8eadf964d23e2a4faa5b38a206aa85c78833c8ce335dddd2c34ba63/ty-0.0.31-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a97de32ee6a619393a4c495e056a1c547de7877510f3152e61345c71d774d2d0", size = 11374903, upload-time = "2026-04-15T15:47:55.893Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c906354ce441e342646582bc9b8f48a676f79f3d061e25de15ff870e015ca14e", size = 11206624, upload-time = "2026-04-15T15:47:51.778Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/70/baad2914cb097453f127a221f8addb2b41926098059cd773c75e6a662fc4/ty-0.0.31-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:275bb7c82afcbf89fe2dbef1b2692f2bc98451f1ee2c8eb809ddd91317822388", size = 10575089, upload-time = "2026-04-15T15:47:49.448Z" },
+    { url = "https://files.pythonhosted.org/packages/83/12/bae3a7bba2e785eb72ce00f9da70eedcb8c5e8299efecbd16e6e436abd82/ty-0.0.31-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:405da247027c6efd1e264886b6ac4a86ab3a4f09200b02e33630efe85f119e53", size = 10642315, upload-time = "2026-04-15T15:48:19.661Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9e/cad04d5d839bc60355cea98c7e09d724ea65f47184def0fae8b90dc54591/ty-0.0.31-py3-none-musllinux_1_2_i686.whl", hash = "sha256:54d9835608eed196853d6643f645c50ce83bcc7fe546cdb3e210c1bcf7c58c09", size = 10834473, upload-time = "2026-04-15T15:48:02.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ba/84112d280182d37690d3d2b4018b2667e42bc281585e607015635310016a/ty-0.0.31-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5ee11be9b07e8c0c6b455ff075a0abe4f194de9476f57624db98eec9df618355", size = 11315785, upload-time = "2026-04-15T15:48:10.754Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9f/ac42dc223d7e0950e97a1854567a8b3e7fe09ad7375adbf91bfb43290482/ty-0.0.31-py3-none-win32.whl", hash = "sha256:7286587aacf3eef0956062d6492b893b02f82b0f22c5e230008e13ff0d216a8b", size = 10187657, upload-time = "2026-04-15T15:48:04.264Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3e/57ba7ea7ecb2f4751644ba91756e2be70e33ef5952c0c41a256a0e4c2437/ty-0.0.31-py3-none-win_amd64.whl", hash = "sha256:81134e25d2a2562ab372f24de8f9bd05034d27d30377a5d7540f259791c6234c", size = 11205258, upload-time = "2026-04-15T15:47:53.759Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/bca669095ccf0a400af941fdf741578d4c2d6719f1b7f10e6dbec10aa862/ty-0.0.31-py3-none-win_arm64.whl", hash = "sha256:e9cb15fad26545c6a608f40f227af3a5513cb376998ca6feddd47ca7d93ffafa", size = 10590392, upload-time = "2026-04-15T15:47:57.968Z" },
 ]
 
 [[package]]
@@ -2234,15 +2382,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.46.0"
+version = "0.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
 ]
 
 [[package]]
@@ -2459,4 +2607,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/98/21be481ab5c08d976e59409828cfcb460a32a737415cf4e9c3f3280acc0b/zizmor-1.24.1.tar.gz", hash = "sha256:54ebb7a7061ebaa3a373126dcbafe970c9228fe274cfc40776a9714d2095b5e6", size = 501427, upload-time = "2026-04-13T18:01:34.666Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/0d/c932a14dfe7d3fed5dbf26a7bf1b7b9dbf277cef1d0b76fbcddae386442d/zizmor-1.24.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fd7c4953aa438aae599db69ed70ac687995e9e3314208bf1be5336479d556c8e", size = 9123014, upload-time = "2026-04-13T18:01:28.834Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/cc/f87ff2ccb9c57f4a1e5e9bd0351f9c84dc724fbd61b8ef70bc7e8abc1e0e/zizmor-1.24.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f44379019188b1a18d560614ab8abac7ce10553ad2ab57d519fa1c214881ff95", size = 8664275, upload-time = "2026-04-13T18:01:24.588Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/64/1dfa166dea03ddff23ee3d6c6ebce8322766f7188e008aa0d3612af3e709/zizmor-1.24.1-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:9b0689c55854edb0f3e6430321a93ca0081d8e34028cdcb47b9504f8a8559c27", size = 8837100, upload-time = "2026-04-13T18:01:18.708Z" },
+    { url = "https://files.pythonhosted.org/packages/65/67/cc411d605fec63b70558d572eb3fc2dbe4e596753e747b74daf5b795c1ed/zizmor-1.24.1-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:61f39674d5ea29640c4b09f3c239b3c9824c646bc790fa3680022e7bb569b375", size = 8430633, upload-time = "2026-04-13T18:01:20.757Z" },
+    { url = "https://files.pythonhosted.org/packages/76/86/f8dfffc7a5348c41bc17dea1f1796ac1a56d5e448f26a4193bc65996f571/zizmor-1.24.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:73083efc7a65e5a58f4439dd781cdcb0394b05a3750e664c7f7e414589dc49b1", size = 9263074, upload-time = "2026-04-13T18:01:31.403Z" },
+    { url = "https://files.pythonhosted.org/packages/14/62/db19dd027b412e92bbea8bd311b733d7726402ee3c734033c714125348f1/zizmor-1.24.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d36a2ba3b6d839acd4542f1a8f42bc34ff902cbff302cdf7916cb4e49dc8c5cc", size = 8863996, upload-time = "2026-04-13T18:01:35.929Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/28/c4f220a14cb100ecc965ea0faed1c1229139861a55e792522274221988b3/zizmor-1.24.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ff5acdd10c66ac27396c0fe14e4604933f6c622ffda38a6aa2857b99c75f5108", size = 8382934, upload-time = "2026-04-13T18:01:27.014Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/df/9593e8851424738a3b682be8958abf0e6a2c170e0c880d7b3bfb5d9eaf15/zizmor-1.24.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b2d873816137296ca5633ad240a574ce49374009a39d43f78a1675e2dba1ab52", size = 9352624, upload-time = "2026-04-13T18:01:16.672Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b9/2c4fe526fc02926206903bfc72dbfbc215f01728eccef8135363d57890c9/zizmor-1.24.1-py3-none-win32.whl", hash = "sha256:c87812173fef2a3449d269e50e93b67b2f40826d10464c7add0c0fd7f0523a2c", size = 7496962, upload-time = "2026-04-13T18:01:22.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/24/710149e5d64d474103165b9eef6f7698827ef2fbb762b034ebc02b11a816/zizmor-1.24.1-py3-none-win_amd64.whl", hash = "sha256:9a0e552bf84f146699a0231dc42cf2cd5cfe140e3f08ff867ac154f62fc1ac2e", size = 8550658, upload-time = "2026-04-13T18:01:33.13Z" },
 ]


### PR DESCRIPTION
## Summary

- **Docs**: relocate DESIGN/WHY/policy markdown under `docs/`, refresh README & CONTRIBUTING, changelog/security/spec updates
- **Deps**: PEP 735 group reshaping, Renovate tweaks, refreshed `uv.lock`
- **Build**: PyPI readme sync helper + tests (`scripts/build/pypi_readme.py`)
- **Engine**: checkpoint layering and transport/async refinements in `src/pyhaul/`
- **Just**: refactor quality recipes (`lint-all`), verbosity, shell helpers (`lint_running`, `run_semgrep`), safe installs
- **Git**: `.gitignore` tweaks

<!-- No release tag requested; merge when CI is green. -->
