### PR TITLE
chore: override release version to 0.5.0

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -21,7 +21,8 @@
   ],
   "packages": {
     ".": {
-      "package-name": "pyhaul"
+      "package-name": "pyhaul",
+      "release-as": "0.5.0"
     }
   }
 }


### PR DESCRIPTION
Adds `release-as: 0.5.0` to the release-please config to override the
auto-detected patch bump. The squash merge of PR #28 used a `docs:` title
but the actual changes include new public API surface (`UnexpectedStatusError`,
`TransportHeaders`, adapter header fidelity fixes) that warrant a minor bump.

**Remove the `release-as` key after the 0.5.0 release PR merges.**