### PR TITLE
docs: tabbed examples for async and landing page, fix docstring rendering

### DIFF
--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -125,7 +125,7 @@ for atomic file replacement: the kernel updates a single directory
 entry, so the operation either fully succeeds or has no effect. There
 is no intermediate state visible to other processes.
 
-### Why same-volume matters
+### Why same-filesystem matters for atomicity
 
 `rename()` is only atomic when source and destination are on the same
 filesystem. A cross-filesystem "rename" is actually copy-then-delete,

--- a/docs/guides/async.md
+++ b/docs/guides/async.md
@@ -4,75 +4,201 @@ pyhaul has a real async engine — not a sync wrapper running in a thread pool.
 [`haul_async()`][pyhaul.async_engine.haul_async] uses `async with` and `async for` natively, sharing all
 non-I/O logic with the sync path.
 
-## Basic async download
-
-```python
-import asyncio
-import httpx
-from pyhaul import haul_async
-
-async def main():
-    async with httpx.AsyncClient() as client:
-        result = await haul_async(
-            "https://example.com/file.bin",
-            client,
-            dest="file.bin",
-        )
-        print(f"done: sha256={result.sha256[:16]}…")
-
-asyncio.run(main())
-```
-
 ## Supported async clients
 
 | Library | Client type | Install |
 | --- | --- | --- |
 | httpx | `httpx.AsyncClient` | `pip install pyhaul[httpx]` |
-| niquests | `niquests.AsyncSession` | `pip install pyhaul[niquests]` |
 | aiohttp | `aiohttp.ClientSession` | `pip install pyhaul[aiohttp]` |
+| niquests | `niquests.AsyncSession` | `pip install pyhaul[niquests]` |
+
+!!! tip "What about urllib3?"
+    urllib3 is sync-only. For async downloads with urllib3, use
+    [`asyncio.to_thread()`](#mixing-sync-clients-with-asyncio) to run the sync
+    `haul()` in a thread pool.
+
+## Basic async download
+
+=== "httpx"
+
+    ```python
+    import asyncio
+    import httpx
+    from pyhaul import haul_async
+
+    async def main():
+        async with httpx.AsyncClient() as client:
+            result = await haul_async(
+                "https://example.com/file.bin",
+                client,
+                dest="file.bin",
+            )
+            print(f"done: sha256={result.sha256[:16]}…")
+
+    asyncio.run(main())
+    ```
+
+=== "aiohttp"
+
+    ```python
+    import asyncio
+    import aiohttp
+    from pyhaul import haul_async
+
+    async def main():
+        async with aiohttp.ClientSession() as session:
+            result = await haul_async(
+                "https://example.com/file.bin",
+                session,
+                dest="file.bin",
+            )
+            print(f"done: sha256={result.sha256[:16]}…")
+
+    asyncio.run(main())
+    ```
+
+=== "niquests"
+
+    ```python
+    import asyncio
+    import niquests
+    from pyhaul import haul_async
+
+    async def main():
+        async with niquests.AsyncSession() as session:
+            result = await haul_async(
+                "https://example.com/file.bin",
+                session,
+                dest="file.bin",
+            )
+            print(f"done: sha256={result.sha256[:16]}…")
+
+    asyncio.run(main())
+    ```
+
+!!! note
+    pyhaul sets `auto_decompress=False` on aiohttp requests internally to
+    ensure raw bytes for accurate resume. Your session's other settings
+    (auth, proxies, timeouts) pass through unchanged.
 
 ## Concurrent downloads with TaskGroup
 
 `asyncio.TaskGroup` (Python 3.11+) is the cleanest way to download multiple
 files concurrently:
 
-```python
-import asyncio
-from pathlib import Path
-import httpx
-from pyhaul import haul_async, PartialHaulError
+=== "httpx"
 
-URLS = [
-    ("https://data.example.edu/census/2024-vol01.csv.gz", Path("data/2024-vol01.csv.gz")),
-    ("https://data.example.edu/census/2024-vol02.csv.gz", Path("data/2024-vol02.csv.gz")),
-    ("https://data.example.edu/census/2024-vol03.csv.gz", Path("data/2024-vol03.csv.gz")),
-]
+    ```python
+    import asyncio
+    from pathlib import Path
+    import httpx
+    from pyhaul import haul_async, PartialHaulError
 
+    URLS = [
+        ("https://data.example.edu/census/2024-vol01.csv.gz", Path("data/vol01.csv.gz")),
+        ("https://data.example.edu/census/2024-vol02.csv.gz", Path("data/vol02.csv.gz")),
+        ("https://data.example.edu/census/2024-vol03.csv.gz", Path("data/vol03.csv.gz")),
+    ]
 
-async def download_one(client: httpx.AsyncClient, url: str, dest: Path):
-    for attempt in range(1, 11):
-        try:
-            await haul_async(url, client, dest=dest)
-            return dest
-        except PartialHaulError:
-            if attempt == 10:
-                raise
-            await asyncio.sleep(min(2**attempt, 30))
+    async def download_one(client: httpx.AsyncClient, url: str, dest: Path):
+        for attempt in range(1, 11):
+            try:
+                await haul_async(url, client, dest=dest)
+                return dest
+            except PartialHaulError:
+                if attempt == 10:
+                    raise
+                await asyncio.sleep(min(2**attempt, 30))
 
+    async def main():
+        Path("data").mkdir(exist_ok=True)
+        async with httpx.AsyncClient() as client:
+            async with asyncio.TaskGroup() as tg:
+                tasks = [
+                    tg.create_task(download_one(client, url, dest))
+                    for url, dest in URLS
+                ]
+        for task in tasks:
+            print(f"done: {task.result()}")
 
-async def main():
-    Path("data").mkdir(exist_ok=True)
-    async with httpx.AsyncClient() as client:
-        async with asyncio.TaskGroup() as tg:
-            tasks = [
-                tg.create_task(download_one(client, url, dest))
-                for url, dest in URLS
-            ]
-    for task in tasks:
-        print(f"done: {task.result()}")
+    asyncio.run(main())
+    ```
 
-asyncio.run(main())
-```
+=== "aiohttp"
+
+    ```python
+    import asyncio
+    from pathlib import Path
+    import aiohttp
+    from pyhaul import haul_async, PartialHaulError
+
+    URLS = [
+        ("https://data.example.edu/census/2024-vol01.csv.gz", Path("data/vol01.csv.gz")),
+        ("https://data.example.edu/census/2024-vol02.csv.gz", Path("data/vol02.csv.gz")),
+        ("https://data.example.edu/census/2024-vol03.csv.gz", Path("data/vol03.csv.gz")),
+    ]
+
+    async def download_one(session: aiohttp.ClientSession, url: str, dest: Path):
+        for attempt in range(1, 11):
+            try:
+                await haul_async(url, session, dest=dest)
+                return dest
+            except PartialHaulError:
+                if attempt == 10:
+                    raise
+                await asyncio.sleep(min(2**attempt, 30))
+
+    async def main():
+        Path("data").mkdir(exist_ok=True)
+        async with aiohttp.ClientSession() as session:
+            async with asyncio.TaskGroup() as tg:
+                tasks = [
+                    tg.create_task(download_one(session, url, dest))
+                    for url, dest in URLS
+                ]
+        for task in tasks:
+            print(f"done: {task.result()}")
+
+    asyncio.run(main())
+    ```
+
+=== "niquests"
+
+    ```python
+    import asyncio
+    from pathlib import Path
+    import niquests
+    from pyhaul import haul_async, PartialHaulError
+
+    URLS = [
+        ("https://data.example.edu/census/2024-vol01.csv.gz", Path("data/vol01.csv.gz")),
+        ("https://data.example.edu/census/2024-vol02.csv.gz", Path("data/vol02.csv.gz")),
+        ("https://data.example.edu/census/2024-vol03.csv.gz", Path("data/vol03.csv.gz")),
+    ]
+
+    async def download_one(session: niquests.AsyncSession, url: str, dest: Path):
+        for attempt in range(1, 11):
+            try:
+                await haul_async(url, session, dest=dest)
+                return dest
+            except PartialHaulError:
+                if attempt == 10:
+                    raise
+                await asyncio.sleep(min(2**attempt, 30))
+
+    async def main():
+        Path("data").mkdir(exist_ok=True)
+        async with niquests.AsyncSession() as session:
+            async with asyncio.TaskGroup() as tg:
+                tasks = [
+                    tg.create_task(download_one(session, url, dest))
+                    for url, dest in URLS
+                ]
+        for task in tasks:
+            print(f"done: {task.result()}")
+
+    asyncio.run(main())
+    ```
 
 Each `haul_async()` call manages its own checkpoint independently. A crash
 partway through leaves each file in a separately resumable state.
@@ -82,71 +208,179 @@ partway through leaves each file in a separately resumable state.
 When downloading many files, limit concurrency to avoid overwhelming the
 server or exhausting file descriptors:
 
-```python
-sem = asyncio.Semaphore(8)
+=== "httpx"
 
-async def download_one(client, url, dest):
-    async with sem:
-        for attempt in range(1, 11):
-            try:
-                await haul_async(url, client, dest=dest)
-                return dest
-            except PartialHaulError:
-                if attempt == 10:
-                    raise
-                await asyncio.sleep(min(2**attempt, 30))
-```
+    ```python
+    sem = asyncio.Semaphore(8)
+
+    async def download_one(client: httpx.AsyncClient, url: str, dest: str):
+        async with sem:
+            for attempt in range(1, 11):
+                try:
+                    await haul_async(url, client, dest=dest)
+                    return dest
+                except PartialHaulError:
+                    if attempt == 10:
+                        raise
+                    await asyncio.sleep(min(2**attempt, 30))
+    ```
+
+=== "aiohttp"
+
+    ```python
+    sem = asyncio.Semaphore(8)
+
+    async def download_one(session: aiohttp.ClientSession, url: str, dest: str):
+        async with sem:
+            for attempt in range(1, 11):
+                try:
+                    await haul_async(url, session, dest=dest)
+                    return dest
+                except PartialHaulError:
+                    if attempt == 10:
+                        raise
+                    await asyncio.sleep(min(2**attempt, 30))
+    ```
+
+=== "niquests"
+
+    ```python
+    sem = asyncio.Semaphore(8)
+
+    async def download_one(session: niquests.AsyncSession, url: str, dest: str):
+        async with sem:
+            for attempt in range(1, 11):
+                try:
+                    await haul_async(url, session, dest=dest)
+                    return dest
+                except PartialHaulError:
+                    if attempt == 10:
+                        raise
+                    await asyncio.sleep(min(2**attempt, 30))
+    ```
 
 ## Async with tenacity
 
 [tenacity](https://tenacity.readthedocs.io/) supports async natively. Decorate
 an `async def` and tenacity handles the await:
 
-```python
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential_jitter,
-)
-from pyhaul import haul_async, PartialHaulError
+=== "httpx"
 
-@retry(
-    retry=retry_if_exception_type(PartialHaulError),
-    wait=wait_exponential_jitter(initial=2, max=30),
-    stop=stop_after_attempt(10),
-)
-async def download(client, url, dest):
-    return await haul_async(url, client, dest=dest)
-```
+    ```python
+    from tenacity import (
+        retry, retry_if_exception, stop_after_attempt, wait_exponential_jitter,
+    )
+    import httpx
+    from pyhaul import haul_async, PartialHaulError, UnexpectedStatusError
 
-## Async with aiohttp
+    def _retryable(exc: BaseException) -> bool:
+        if isinstance(exc, (PartialHaulError, httpx.TransportError)):
+            return True
+        return isinstance(exc, UnexpectedStatusError) and exc.is_transient
 
-aiohttp has a different session model from httpx. The adapter handles the
-differences:
+    @retry(
+        retry=retry_if_exception(_retryable),
+        wait=wait_exponential_jitter(initial=2, max=60),
+        stop=stop_after_attempt(10),
+    )
+    async def download(client: httpx.AsyncClient, url: str, dest: str):
+        return await haul_async(url, client, dest=dest)
+    ```
 
-```python
-import asyncio
-import aiohttp
-from pyhaul import haul_async
+=== "aiohttp"
 
-async def main():
-    async with aiohttp.ClientSession() as session:
-        result = await haul_async(
-            "https://example.com/file.bin",
-            session,
-            dest="file.bin",
+    ```python
+    from tenacity import (
+        retry, retry_if_exception, stop_after_attempt, wait_exponential_jitter,
+    )
+    import aiohttp
+    from pyhaul import haul_async, PartialHaulError, UnexpectedStatusError
+
+    def _retryable(exc: BaseException) -> bool:
+        if isinstance(exc, (PartialHaulError, aiohttp.ClientError)):
+            return True
+        return isinstance(exc, UnexpectedStatusError) and exc.is_transient
+
+    @retry(
+        retry=retry_if_exception(_retryable),
+        wait=wait_exponential_jitter(initial=2, max=60),
+        stop=stop_after_attempt(10),
+    )
+    async def download(session: aiohttp.ClientSession, url: str, dest: str):
+        return await haul_async(url, session, dest=dest)
+    ```
+
+=== "niquests"
+
+    ```python
+    from tenacity import (
+        retry, retry_if_exception, stop_after_attempt, wait_exponential_jitter,
+    )
+    import niquests
+    from pyhaul import haul_async, PartialHaulError, UnexpectedStatusError
+
+    def _retryable(exc: BaseException) -> bool:
+        if isinstance(exc, (PartialHaulError, niquests.RequestException)):
+            return True
+        return isinstance(exc, UnexpectedStatusError) and exc.is_transient
+
+    @retry(
+        retry=retry_if_exception(_retryable),
+        wait=wait_exponential_jitter(initial=2, max=60),
+        stop=stop_after_attempt(10),
+    )
+    async def download(session: niquests.AsyncSession, url: str, dest: str):
+        return await haul_async(url, session, dest=dest)
+    ```
+
+## Mixing sync clients with asyncio
+
+urllib3 and `requests.Session` are sync-only. If your application is async but
+you need one of these clients, use [`asyncio.to_thread()`](https://docs.python.org/3/library/asyncio-task.html#asyncio.to_thread)
+to run the sync `haul()` in a thread without blocking the event loop:
+
+=== "urllib3"
+
+    ```python
+    import asyncio
+    import urllib3
+    from pyhaul import haul
+
+    async def main():
+        pool = urllib3.PoolManager()
+        result = await asyncio.to_thread(
+            haul, "https://example.com/file.bin", pool, dest="file.bin",
         )
+        print(f"done: sha256={result.sha256[:16]}…")
+        pool.clear()
 
-asyncio.run(main())
-```
+    asyncio.run(main())
+    ```
 
-!!! note
-    pyhaul sets `auto_decompress=False` on aiohttp requests internally to
-    ensure raw bytes for accurate resume. Your session's other settings
-    (auth, proxies, timeouts) pass through unchanged.
+=== "requests"
 
-## Progress reporting in async
+    ```python
+    import asyncio
+    import requests
+    from pyhaul import haul
+
+    async def main():
+        with requests.Session() as session:
+            result = await asyncio.to_thread(
+                haul, "https://example.com/file.bin", session, dest="file.bin",
+            )
+            print(f"done: sha256={result.sha256[:16]}…")
+
+    asyncio.run(main())
+    ```
+
+!!! warning
+    `asyncio.to_thread()` runs the download in a separate OS thread.
+    You get non-blocking I/O from the event loop's perspective, but you
+    lose the benefits of true async streaming (single-threaded concurrency,
+    lower memory, backpressure). Prefer a native async client when possible.
+
+## Progress reporting
 
 The `on_progress` callback is synchronous even in async mode — pass a
 [`HaulState`][pyhaul._types.HaulState] to track progress. Keep the callback fast:
@@ -155,10 +389,15 @@ The `on_progress` callback is synchronous even in async mode — pass a
 from pyhaul import haul_async, HaulState
 
 state = HaulState()
+high_water = 0
 
 def show_progress(state: HaulState):
+    global high_water
+    # After a retry, valid_length may rewind to the last checkpoint.
+    # Use a high-water mark to avoid showing backward progress.
+    high_water = max(high_water, state.valid_length)
     if state.reported_length:
-        pct = state.valid_length / state.reported_length * 100
+        pct = high_water / state.reported_length * 100
         print(f"\r{pct:.1f}%", end="", flush=True)
 
 async def main():

--- a/docs/guides/bulk-downloads.md
+++ b/docs/guides/bulk-downloads.md
@@ -89,8 +89,9 @@ with httpx.Client() as client:
 ```
 
 !!! note
-    `httpx.Client` is thread-safe. `requests.Session` is *not* — create one
-    session per thread, or use `niquests.Session` (thread-safe) instead.
+    `requests.Session` is the only sync client that is *not* thread-safe.
+    Create one session per thread, or switch to `niquests.Session`, `httpx.Client`,
+    or `urllib3.PoolManager` — all of which are thread-safe.
 
 ## Parallel downloads with asyncio
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,18 +6,124 @@ pyhaul borrows your existing HTTP session and handles byte-range negotiation,
 crash-safe checkpointing, and validation. One call to [`haul()`][pyhaul.engine.haul] = one request.
 It either succeeds, or it saves progress so the next call resumes.
 
-```bash
-pip install pyhaul[httpx]   # or: niquests, requests, urllib3, aiohttp
-```
+=== "httpx"
 
-```python
-import httpx
-from pyhaul import haul
+    ```bash
+    pip install pyhaul[httpx]
+    ```
 
-with httpx.Client() as client:
-    result = haul("https://example.com/big.zip", client, dest="big.zip")
-    print(f"done: sha256={result.sha256[:16]}…")
-```
+    ```python
+    import httpx
+    from pathlib import Path
+    from pyhaul import haul, PartialHaulError
+
+    dest = Path("big.zip")
+    with httpx.Client() as client:
+        for _ in range(10):
+            try:
+                result = haul("https://example.com/big.zip", client, dest=dest)
+                break
+            except PartialHaulError:
+                pass  # only retryable error; others propagate
+
+    print(f"done: {dest.stat().st_size:,} bytes")
+    ```
+
+=== "aiohttp"
+
+    ```bash
+    pip install pyhaul[aiohttp]
+    ```
+
+    ```python
+    import asyncio
+    import aiohttp
+    from pathlib import Path
+    from pyhaul import haul_async, PartialHaulError
+
+    async def main():
+        dest = Path("big.zip")
+        async with aiohttp.ClientSession() as session:
+            for _ in range(10):
+                try:
+                    result = await haul_async("https://example.com/big.zip", session, dest=dest)
+                    break
+                except PartialHaulError:
+                    pass
+        print(f"done: {dest.stat().st_size:,} bytes")
+
+    asyncio.run(main())
+    ```
+
+=== "requests"
+
+    ```bash
+    pip install pyhaul[requests]
+    ```
+
+    ```python
+    import requests
+    from pathlib import Path
+    from pyhaul import haul, PartialHaulError
+
+    dest = Path("big.zip")
+    with requests.Session() as session:
+        for _ in range(10):
+            try:
+                result = haul("https://example.com/big.zip", session, dest=dest)
+                break
+            except PartialHaulError:
+                pass
+
+    print(f"done: {dest.stat().st_size:,} bytes")
+    ```
+
+=== "niquests"
+
+    ```bash
+    pip install pyhaul[niquests]
+    ```
+
+    ```python
+    import niquests
+    from pathlib import Path
+    from pyhaul import haul, PartialHaulError
+
+    dest = Path("big.zip")
+    with niquests.Session() as session:
+        for _ in range(10):
+            try:
+                result = haul("https://example.com/big.zip", session, dest=dest)
+                break
+            except PartialHaulError:
+                pass
+
+    print(f"done: {dest.stat().st_size:,} bytes")
+    ```
+
+=== "urllib3"
+
+    ```bash
+    pip install pyhaul[urllib3]
+    ```
+
+    ```python
+    import urllib3
+    from pathlib import Path
+    from pyhaul import haul, PartialHaulError
+
+    dest = Path("big.zip")
+    pool = urllib3.PoolManager()
+    for _ in range(10):
+        try:
+            result = haul("https://example.com/big.zip", pool, dest=dest)
+            break
+        except PartialHaulError:
+            pass
+
+    print(f"done: {dest.stat().st_size:,} bytes")
+    pool.clear()
+    ```
 
 ## Guarantees
 

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -51,6 +51,7 @@ markdown_extensions:
   - toc:
       permalink: true
   - attr_list
+  - md_in_html
 
 plugins:
   - search
@@ -81,9 +82,9 @@ nav:
   - Guides:
       - Bulk Downloads: guides/bulk-downloads.md
       - HTTP Client Adapters: guides/adapters.md
-      - Writing a Custom Adapter: guides/custom-transport.md
       - Retry Patterns: guides/retry.md
       - Async Usage: guides/async.md
+      - Writing a Custom Adapter: guides/custom-transport.md
   - Explanation:
       - Why pyhaul Exists: explanation/why.md
       - Design & Architecture: explanation/design.md

--- a/src/pyhaul/transport/_headers.py
+++ b/src/pyhaul/transport/_headers.py
@@ -1,6 +1,6 @@
 """Case-insensitive, immutable, multi-value HTTP response headers.
 
-Implements :class:`collections.abc.Mapping[str, str]` so bracket access,
+Implements `collections.abc.Mapping[str, str]` so bracket access,
 ``in``, ``len()``, iteration, ``.keys()``, ``.values()``, and
 ``.items()`` all work out of the box.
 
@@ -50,7 +50,7 @@ class TransportHeaders(Mapping[str, str]):
     Field names are matched case-insensitively per HTTP semantics.
     Duplicate names are preserved in wire order.
 
-    Construct via :meth:`build`, :meth:`from_pairs`, or :meth:`from_mapping`.
+    Construct via `build`, `from_pairs`, or `from_mapping`.
     """
 
     __slots__ = ("_hash", "_index", "_items")
@@ -110,7 +110,7 @@ class TransportHeaders(Mapping[str, str]):
     def from_pairs(cls, pairs: Iterable[Pair]) -> Self:
         """Build from an ordered ``(name, value)`` iterable.
 
-        Preserves duplicate names and wire order for :meth:`get_all`.
+        Preserves duplicate names and wire order for `get_all`.
         """
         return cls(tuple((_norm_name(n), _norm_value(v)) for n, v in pairs))
 
@@ -151,7 +151,7 @@ class TransportHeaders(Mapping[str, str]):
         return tuple(self._items[i][1] for i in idx) if idx else ()
 
     getlist = get_all
-    """Alias for :meth:`get_all` (werkzeug / multidict naming)."""
+    """Alias for `get_all` (werkzeug / multidict naming)."""
 
     def multi_items(self) -> Iterator[Pair]:
         """Yield every ``(name, value)`` pair, including duplicates."""

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.12"
 
 [options]
-exclude-newer = "2026-04-25T04:04:35.440164Z"
+exclude-newer = "2026-04-25T11:23:52.835514Z"
 exclude-newer-span = "PT72H"
 
 [[package]]
@@ -1844,7 +1844,7 @@ wheels = [
 
 [[package]]
 name = "pyhaul"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
- Enable `md_in_html` extension for grid cards on landing page
- Add tabbed hero examples (all 5 clients) on landing page
- Rework async guide with tabs for httpx/aiohttp/niquests throughout
- Add "Mixing sync clients with asyncio" section (urllib3 + requests via `asyncio.to_thread()`)
- Add high-water mark to progress callback example for non-monotonic retry loops
- Fix Sphinx `:meth:` / `:class:` references in `TransportHeaders` docstrings
- Tighten thread-safety note in bulk-downloads guide
- Rename "Why same-volume matters" heading for clarity
- Move "Writing a Custom Adapter" to end of Guides nav