### PR TITLE
fix: map retryable transport errors to PartialHaulError and offload async disk I/O

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,6 +25,7 @@ _shell_export := 'export JUST_SHOW_RUNNING=' + quote(_show_running)
 _bash_lint_helpers := '''
   JUST_DIM=$'\033[2m'
   JUST_GREEN=$'\033[32m'
+  JUST_RED=$'\033[31m'
   JUST_RST=$'\033[0m'
   lint_running() {
     [[ "${JUST_SHOW_RUNNING:-}" == "yes" ]] || return 0
@@ -32,6 +33,20 @@ _bash_lint_helpers := '''
   }
   lint_ok() {
     printf '%s  ok%s  %s\n' "$JUST_GREEN" "$JUST_RST" "$1" >&2
+  }
+  lint_fail() {
+    printf '%sFAIL%s  %s\n' "$JUST_RED" "$JUST_RST" "$1" >&2
+  }
+  # run_quiet NAME CMD [ARGS…]  — run quietly; on failure, re-run loud.
+  run_quiet() {
+    local _name="$1"; shift
+    lint_running "$_name"
+    local _out _code
+    _out=$("$@" 2>&1) && { lint_ok "$_name"; return 0; }
+    _code=$?
+    lint_fail "$_name"
+    printf '%s\n' "$_out" >&2
+    return "$_code"
   }
   run_semgrep() {
     lint_running "semgrep"
@@ -137,27 +152,13 @@ _lint-py:
     #!/usr/bin/env bash
     set -euo pipefail
     {{ _lint_bundle }}
-    lint_running "ruff check"
-    uv run ruff check --quiet .
-    lint_ok "ruff check"
-    lint_running "ruff format"
-    uv run ruff format --quiet --check .
-    lint_ok "ruff format"
-    lint_running "mypy"
-    uv run mypy --no-error-summary src tests examples scripts
-    lint_ok "mypy"
-    lint_running "pyright"
-    _out=$(uv run pyright 2>&1) || { echo "$_out"; exit 1; }
-    lint_ok "pyright"
-    lint_running "ty"
-    uv run ty check --quiet --quiet
-    lint_ok "ty"
-    lint_running "validate-pyproject"
-    uv run validate-pyproject pyproject.toml > /dev/null
-    lint_ok "validate-pyproject"
-    lint_running "interrogate"
-    uv run interrogate --quiet src/pyhaul/
-    lint_ok "interrogate"
+    run_quiet "ruff check"        uv run ruff check --quiet .
+    run_quiet "ruff format"       uv run ruff format --quiet --check .
+    run_quiet "mypy"              uv run mypy --no-error-summary src tests examples scripts
+    run_quiet "pyright"           uv run pyright
+    run_quiet "ty"                uv run ty check --quiet --quiet
+    run_quiet "validate-pyproject" uv run validate-pyproject pyproject.toml
+    run_quiet "interrogate"       uv run interrogate --quiet src/pyhaul/
     run_semgrep
 
 [private]
@@ -182,9 +183,7 @@ _lint-sh:
         [[ -f "$hook" ]] && targets+=("$hook")
     done
     (( ${#targets[@]} == 0 )) && exit 0
-    lint_running "shellcheck"
-    shellcheck -f quiet -x "${targets[@]}"
-    lint_ok "shellcheck"
+    run_quiet "shellcheck" shellcheck -f quiet -x "${targets[@]}"
 
 [private]
 _lint-sh-fix:
@@ -195,9 +194,7 @@ _lint-docs:
     #!/usr/bin/env bash
     set -euo pipefail
     {{ _lint_bundle }}
-    lint_running "rumdl"
-    uv run rumdl check --quiet .
-    lint_ok "rumdl"
+    run_quiet "rumdl" uv run rumdl check --quiet .
 
 [private]
 _lint-workflows:
@@ -208,15 +205,9 @@ _lint-workflows:
       exit 1
     }
     {{ _lint_bundle }}
-    lint_running "actionlint"
-    actionlint -no-color
-    lint_ok "actionlint"
-    lint_running "check-jsonschema (renovate.json)"
-    uv run check-jsonschema --schemafile "https://docs.renovatebot.com/renovate-schema.json" renovate.json
-    lint_ok "check-jsonschema (renovate.json)"
-    lint_running "zizmor"
-    uv run zizmor -q .
-    lint_ok "zizmor"
+    run_quiet "actionlint"                  actionlint -no-color
+    run_quiet "check-jsonschema (renovate.json)" uv run check-jsonschema --schemafile "https://docs.renovatebot.com/renovate-schema.json" renovate.json
+    run_quiet "zizmor"                      uv run zizmor -q .
 
 [private]
 _lint-docs-fix:
@@ -227,9 +218,7 @@ _lint-spell:
     #!/usr/bin/env bash
     set -euo pipefail
     {{ _lint_bundle }}
-    lint_running "codespell"
-    uv run codespell src tests docs examples scripts *.md *.toml
-    lint_ok "codespell"
+    run_quiet "codespell" uv run codespell src tests docs examples scripts *.md *.toml
 
 [private]
 _safe-install src dest:

--- a/src/pyhaul/_engine_common.py
+++ b/src/pyhaul/_engine_common.py
@@ -385,14 +385,14 @@ def write_chunk(
 
     if plan.bytes_since_flush >= flush_every:
         datasync(fd)
-        _save_checkpoint(prep.ctrl_path, plan, prep)
+        save_checkpoint(prep.ctrl_path, plan, prep)
         plan.bytes_since_flush = 0
 
 
 def after_stream(plan: StreamPlan, prep: PrepareHaul, state: HaulState) -> CompleteHaul:
     """Post-loop: check completeness, trim junk tail, finalize or raise partial."""
     if plan.extent is not None and plan.cursor < plan.extent:
-        _save_checkpoint(prep.ctrl_path, plan, prep)
+        save_checkpoint(prep.ctrl_path, plan, prep)
         raise PartialHaulError("stream ended before extent reached")
 
     actual = prep.part_path.stat().st_size
@@ -457,7 +457,8 @@ def _reset_checkpoint(ctrl_path: Path, start: int, block_size: int) -> None:
     write_atomic(ctrl_path, registry.dump(cp))
 
 
-def _save_checkpoint(path: Path, plan: StreamPlan, _prep: PrepareHaul) -> None:
+def save_checkpoint(path: Path, plan: StreamPlan, _prep: PrepareHaul) -> None:
+    """Atomically persist the current download checkpoint to *path*."""
     cp = Checkpoint(
         version=LATEST_VERSION,
         start=plan.start,
@@ -480,5 +481,5 @@ def flush_dirty(fd: int, plan: StreamPlan, prep: PrepareHaul) -> None:
     """
     if plan.bytes_since_flush > 0:
         datasync(fd)
-        _save_checkpoint(prep.ctrl_path, plan, prep)
+        save_checkpoint(prep.ctrl_path, plan, prep)
         plan.bytes_since_flush = 0

--- a/src/pyhaul/async_engine.py
+++ b/src/pyhaul/async_engine.py
@@ -3,10 +3,15 @@
 Async mirror of :mod:`pyhaul.engine`.  All non-I/O logic is shared via
 :mod:`pyhaul._engine_common`; only the session context manager and the
 chunk iterator differ (``async with`` / ``async for``).
+
+Blocking disk I/O (``fdatasync``, checkpoint writes) is offloaded to the
+default executor via :func:`asyncio.loop.run_in_executor` so the event
+loop stays responsive for other tasks during periodic flushes.
 """
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 import os
@@ -16,6 +21,7 @@ from pathlib import Path
 from pyhaul._engine_common import (
     DEFAULT_CHUNK,
     DEFAULT_FLUSH,
+    PrepareHaul,
     StreamPlan,
     after_stream,
     datasync,
@@ -23,14 +29,20 @@ from pyhaul._engine_common import (
     handle_response,
     open_part_file,
     prepare_haul,
-    write_chunk,
+    save_checkpoint,
 )
 from pyhaul._session_dispatch import coerce_async_session
-from pyhaul._types import CompleteHaul, HaulState
-from pyhaul.transport.errors import TransportError
+from pyhaul._types import CompleteHaul, HaulState, PartialHaulError
+from pyhaul.transport.errors import TransportConnectionError, TransportError
 from pyhaul.transport.protocols import AsyncTransportSession
 
 logger = logging.getLogger(__name__)
+
+
+def _sync_flush(fd: int, plan: StreamPlan, prep: PrepareHaul) -> None:
+    """Flush data to disk and persist checkpoint (runs in executor thread)."""
+    datasync(fd)
+    save_checkpoint(prep.ctrl_path, plan, prep)
 
 
 async def haul_async(
@@ -68,6 +80,7 @@ async def haul_async(
         state = HaulState()
     transport = coerce_async_session(client)
     prep = prepare_haul(url, dest)
+    loop = asyncio.get_running_loop()
 
     try:
         async with transport.stream_get(prep.parsed_url, headers=prep.merged_headers) as resp:
@@ -84,19 +97,34 @@ async def haul_async(
             fd = open_part_file(plan, prep.part_path)
             try:
                 async for chunk in resp.aiter_raw_bytes(chunk_size=chunk_size):
-                    write_chunk(fd, chunk, plan, prep, state, flush_every)
+                    os.write(fd, chunk)
+                    n = len(chunk)
+                    plan.cursor += n
+                    plan.bytes_since_flush += n
+                    state.bytes_read += n
+                    state.valid_length = plan.cursor
+                    plan.hb.update(chunk)
+                    state.hashes = plan.hb.completed_hashes.copy()
+
+                    if plan.bytes_since_flush >= flush_every:
+                        await loop.run_in_executor(None, _sync_flush, fd, plan, prep)
+                        plan.bytes_since_flush = 0
+
                     if on_progress is not None:
                         on_progress(state)
-                datasync(fd)
-            except TransportError:
+
+                await loop.run_in_executor(None, datasync, fd)
+            except TransportError as exc:
                 flush_dirty(fd, plan, prep)
                 os.close(fd)
-                raise
+                raise PartialHaulError("connection lost during stream") from exc
             finally:
                 with contextlib.suppress(OSError):
                     os.close(fd)
 
             return after_stream(plan, prep, state)
+    except TransportConnectionError as ce:
+        raise PartialHaulError("connection error") from ce
     except TransportError as te:
         original = te.__cause__
         if original is not None:

--- a/src/pyhaul/engine.py
+++ b/src/pyhaul/engine.py
@@ -25,8 +25,8 @@ from pyhaul._engine_common import (
     write_chunk,
 )
 from pyhaul._session_dispatch import coerce_sync_session
-from pyhaul._types import CompleteHaul, HaulState
-from pyhaul.transport.errors import TransportError
+from pyhaul._types import CompleteHaul, HaulState, PartialHaulError
+from pyhaul.transport.errors import TransportConnectionError, TransportError
 from pyhaul.transport.protocols import TransportSession
 
 logger = logging.getLogger(__name__)
@@ -87,15 +87,17 @@ def haul(
                     if on_progress is not None:
                         on_progress(state)
                 datasync(fd)
-            except TransportError:
+            except TransportError as exc:
                 flush_dirty(fd, plan, prep)
                 os.close(fd)
-                raise
+                raise PartialHaulError("connection lost during stream") from exc
             finally:
                 with contextlib.suppress(OSError):
                     os.close(fd)
 
             return after_stream(plan, prep, state)
+    except TransportConnectionError as ce:
+        raise PartialHaulError("connection error") from ce
     except TransportError as te:
         original = te.__cause__
         if original is not None:

--- a/tests/test_async_engine.py
+++ b/tests/test_async_engine.py
@@ -378,3 +378,106 @@ class TestAsyncCrashRecovery:
 
         assert isinstance(result, CompleteHaul)
         assert dest.read_bytes() == full_body
+
+
+# ---------------------------------------------------------------------------
+# Executor offloading
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncExecutorOffload:
+    """Verify periodic flushes and final datasync are offloaded off the event loop."""
+
+    @pytest.mark.anyio
+    async def test_periodic_flush_uses_executor(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When bytes_since_flush >= flush_every, _sync_flush runs via run_in_executor."""
+        import asyncio
+        from collections.abc import Callable
+        from typing import Any
+
+        from pyhaul._engine_common import datasync
+        from pyhaul.async_engine import _sync_flush, haul_async
+
+        body = b"A" * 200
+        session = AsyncMockSession()
+        session.add_response(_make_206(body, start=0, total=len(body)))
+
+        dest = tmp_path / "out.bin"
+
+        offloaded_fns: list[Callable[..., Any]] = []
+        real_run_in_executor = asyncio.get_running_loop().run_in_executor
+
+        def tracking_run_in_executor(executor: Any, fn: Callable[..., Any], /, *args: Any) -> Any:
+            offloaded_fns.append(fn)
+            return real_run_in_executor(executor, fn, *args)
+
+        monkeypatch.setattr(asyncio.get_running_loop(), "run_in_executor", tracking_run_in_executor)
+
+        await haul_async(
+            _TEST_URL,
+            session,
+            dest=str(dest),
+            flush_every=50,
+            chunk_size=60,
+        )
+
+        assert dest.read_bytes() == body
+        assert len(offloaded_fns) >= 2, f"expected >=2 executor calls, got {len(offloaded_fns)}"
+        assert _sync_flush in offloaded_fns, "periodic flush should be offloaded"
+        assert datasync in offloaded_fns, "final datasync should be offloaded"
+
+    @pytest.mark.anyio
+    async def test_correctness_with_aggressive_flushing(self, tmp_path: Path) -> None:
+        """Small flush_every + small chunk_size still produces correct output."""
+        from pyhaul.async_engine import haul_async
+
+        body = b"The quick brown fox jumps over the lazy dog."
+        session = AsyncMockSession()
+        session.add_response(_make_206(body, start=0, total=len(body)))
+
+        dest = tmp_path / "out.bin"
+        state = HaulState()
+        result = await haul_async(
+            _TEST_URL,
+            session,
+            dest=str(dest),
+            state=state,
+            flush_every=8,
+            chunk_size=5,
+        )
+
+        assert isinstance(result, CompleteHaul)
+        assert dest.read_bytes() == body
+        assert state.bytes_read == len(body)
+        assert state.valid_length == len(body)
+        assert state.is_complete is True
+
+    @pytest.mark.anyio
+    async def test_checkpoint_written_during_flush(self, tmp_path: Path) -> None:
+        """Periodic executor flush actually persists a checkpoint file."""
+        from pyhaul.async_engine import haul_async
+
+        body = b"X" * 300
+        session = AsyncMockSession()
+        session.add_response(_make_206(body, start=0, total=len(body)))
+
+        dest = tmp_path / "out.bin"
+        part_path = dest.with_suffix(dest.suffix + ".part")
+        ctrl = ctrl_path_for(part_path)
+
+        checkpoints_seen: list[bool] = []
+
+        def spy_progress(st: HaulState) -> None:
+            checkpoints_seen.append(ctrl.exists())
+
+        await haul_async(
+            _TEST_URL,
+            session,
+            dest=str(dest),
+            flush_every=50,
+            chunk_size=60,
+            on_progress=spy_progress,
+        )
+
+        assert dest.read_bytes() == body
+        assert any(checkpoints_seen), "checkpoint should have been written at least once during download"

--- a/tests/test_live_async.py
+++ b/tests/test_live_async.py
@@ -1,0 +1,396 @@
+"""Live async integration tests: concurrent haul_async over real HTTP.
+
+Exercises the ``TaskGroup`` + ``Semaphore`` concurrency pattern shown in
+``docs/guides/async.md``, against a real threaded HTTP server, once per
+installed async client (httpx, aiohttp, niquests).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import gc
+import http.server as _http_server
+import socket
+import threading
+import time
+from collections.abc import AsyncIterator, Generator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+from pyhaul._types import CompleteHaul, HashBuilder, HaulState, PartialHaulError
+from pyhaul.async_engine import haul_async
+
+ASYNC_BACKENDS: tuple[str, ...] = ("httpx", "aiohttp", "niquests")
+
+# ---------------------------------------------------------------------------
+# Async client factories
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _make_async_client(backend: str) -> AsyncIterator[object]:
+    """Create and yield a native async HTTP client for *backend*."""
+    if backend == "httpx":
+        import httpx
+
+        async with httpx.AsyncClient() as client:
+            yield client
+    elif backend == "aiohttp":
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            yield session
+    elif backend == "niquests":
+        import niquests
+
+        async with niquests.AsyncSession() as session:
+            yield session
+    else:
+        msg = f"unknown async backend {backend!r}"
+        raise ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Minimal HTTP server (multi-file, each URL → different content)
+# ---------------------------------------------------------------------------
+
+
+def _deterministic(size: int, *, seed: int = 0) -> bytes:
+    return bytes(((i * 37 + seed + 11) & 0xFF) for i in range(size))
+
+
+def _tree_hash(data: bytes) -> str:
+    """Compute the tree-hash that ``CompleteHaul.sha256`` uses."""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(data)
+        p = Path(tmp.name)
+    try:
+        return HashBuilder.hash_file(p)
+    finally:
+        p.unlink()
+
+
+class _ServerFaults:
+    """Thread-safe per-file request counter for fault injection."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._hits: dict[int, int] = {}
+        self.truncate_first_n: int = 0
+
+    def hit(self, file_idx: int) -> int:
+        """Record a request for *file_idx*, return the 0-based attempt number."""
+        with self._lock:
+            attempt = self._hits.get(file_idx, 0)
+            self._hits[file_idx] = attempt + 1
+            return attempt
+
+    def should_truncate(self, file_idx: int) -> bool:
+        """True if this request should be truncated mid-body."""
+        attempt = self.hit(file_idx)
+        return attempt < self.truncate_first_n
+
+
+class _MultiFileHandler(_http_server.BaseHTTPRequestHandler):
+    """Serves /0, /1, /2, … each with deterministic content seeded by index."""
+
+    file_size: int = 0
+    file_count: int = 0
+    faults: _ServerFaults
+
+    def do_GET(self) -> None:
+        try:
+            idx = int(self.path.strip("/"))
+        except (ValueError, IndexError):
+            self.send_error(404)
+            return
+
+        content = _deterministic(self.file_size, seed=idx)
+        range_hdr = self.headers.get("Range", "")
+        truncate = self.faults.should_truncate(idx)
+
+        if range_hdr:
+            self._send_206(content, range_hdr, truncate=truncate)
+        else:
+            self._send_200(content, truncate=truncate)
+
+    def _send_200(self, content: bytes, *, truncate: bool = False) -> None:
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(content)))
+        self.send_header("ETag", f'"seed-{len(content)}"')
+        self.end_headers()
+        if truncate:
+            self.wfile.write(content[: len(content) // 2])
+            self.wfile.flush()
+            self.connection.close()
+            self.close_connection = True
+        else:
+            self.wfile.write(content)
+
+    def _send_206(self, content: bytes, range_hdr: str, *, truncate: bool = False) -> None:
+        try:
+            start_s, end_s = range_hdr.replace("bytes=", "").split("-")
+            start = int(start_s)
+            end = int(end_s) if end_s else len(content) - 1
+        except (ValueError, IndexError):
+            self._send_200(content)
+            return
+
+        end = min(end, len(content) - 1)
+        chunk = content[start : end + 1]
+
+        self.send_response(206)
+        self.send_header("Content-Range", f"bytes {start}-{end}/{len(content)}")
+        self.send_header("Content-Length", str(len(chunk)))
+        self.send_header("ETag", f'"seed-{len(content)}"')
+        self.end_headers()
+        if truncate:
+            self.wfile.write(chunk[: len(chunk) // 2])
+            self.wfile.flush()
+            self.connection.close()
+            self.close_connection = True
+        else:
+            self.wfile.write(chunk)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+class _ThreadingHTTPServer(_http_server.ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def shutdown_request(self, request: socket.socket) -> None:  # type: ignore[override]
+        """Suppress OSError from double-close after forced truncation."""
+        with contextlib.suppress(OSError):
+            super().shutdown_request(request)
+
+
+@pytest.fixture(params=ASYNC_BACKENDS)
+def async_backend(request: pytest.FixtureRequest) -> str:
+    """Yield each async backend name, skipping if not installed."""
+    pytest.importorskip(request.param)
+    return str(request.param)
+
+
+@pytest.fixture
+def multi_file_server(tmp_path: Path) -> Generator[tuple[str, Path, int, int, _ServerFaults]]:
+    """Spin up an HTTP server serving N deterministic files.
+
+    Yields ``(base_url, dest_dir, file_count, file_size, faults)``.
+    """
+    file_count = 8
+    file_size = 16 * 1024
+    faults = _ServerFaults()
+
+    handler_cls = type(
+        "_Handler",
+        (_MultiFileHandler,),
+        {"file_size": file_size, "file_count": file_count, "faults": faults},
+    )
+    srv = _ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    port = srv.server_address[1]
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+
+    dest_dir = tmp_path / "downloads"
+    dest_dir.mkdir()
+
+    try:
+        yield f"http://127.0.0.1:{port}", dest_dir, file_count, file_size, faults
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        thread.join(timeout=1.0)
+        time.sleep(0.01)
+        gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentAsyncDownloads:
+    """Multiple haul_async calls in a TaskGroup, mirroring the docs pattern."""
+
+    @pytest.mark.anyio
+    async def test_taskgroup_all_complete(
+        self,
+        async_backend: str,
+        multi_file_server: tuple[str, Path, int, int, _ServerFaults],
+    ) -> None:
+        base_url, dest_dir, file_count, file_size, _faults = multi_file_server
+
+        results: dict[int, CompleteHaul] = {}
+
+        async with _make_async_client(async_backend) as client, asyncio.TaskGroup() as tg:
+            for i in range(file_count):
+
+                async def _download(idx: int = i) -> None:
+                    url = f"{base_url}/{idx}"
+                    dest = dest_dir / f"file_{idx}.bin"
+                    results[idx] = await haul_async(url, client, dest=str(dest))
+
+                tg.create_task(_download())
+
+        assert len(results) == file_count
+        for i in range(file_count):
+            expected = _deterministic(file_size, seed=i)
+            dest = dest_dir / f"file_{i}.bin"
+            assert dest.exists(), f"file_{i}.bin missing"
+            assert dest.read_bytes() == expected
+            assert results[i].sha256 == _tree_hash(expected)
+
+    @pytest.mark.anyio
+    async def test_semaphore_limits_concurrency(
+        self,
+        async_backend: str,
+        multi_file_server: tuple[str, Path, int, int, _ServerFaults],
+    ) -> None:
+        """Semaphore-bounded concurrency still completes all files."""
+        base_url, dest_dir, file_count, file_size, _faults = multi_file_server
+        sem = asyncio.Semaphore(3)
+        peak_concurrent = 0
+        current_concurrent = 0
+        lock = asyncio.Lock()
+
+        async def _bounded_download(client: object, idx: int) -> CompleteHaul:
+            nonlocal peak_concurrent, current_concurrent
+            async with sem:
+                async with lock:
+                    current_concurrent += 1
+                    peak_concurrent = max(peak_concurrent, current_concurrent)
+                try:
+                    url = f"{base_url}/{idx}"
+                    dest = dest_dir / f"file_{idx}.bin"
+                    return await haul_async(url, client, dest=str(dest))
+                finally:
+                    async with lock:
+                        current_concurrent -= 1
+
+        async with _make_async_client(async_backend) as client, asyncio.TaskGroup() as tg:
+            tasks = [tg.create_task(_bounded_download(client, i)) for i in range(file_count)]
+
+        for i, task in enumerate(tasks):
+            expected = _deterministic(file_size, seed=i)
+            dest = dest_dir / f"file_{i}.bin"
+            assert dest.read_bytes() == expected
+            assert task.result().sha256 == _tree_hash(expected)
+
+        assert peak_concurrent <= 3, f"semaphore violated: peak was {peak_concurrent}"
+
+    @pytest.mark.anyio
+    async def test_progress_tracking_per_file(
+        self,
+        async_backend: str,
+        multi_file_server: tuple[str, Path, int, int, _ServerFaults],
+    ) -> None:
+        """Each concurrent download gets independent state + progress callbacks."""
+        base_url, dest_dir, file_count, _file_size, _faults = multi_file_server
+        progress_counts: dict[int, int] = {}
+
+        async def _download_with_progress(client: object, idx: int) -> CompleteHaul:
+            state = HaulState()
+            count = 0
+
+            def on_progress(_st: HaulState) -> None:
+                nonlocal count
+                count += 1
+
+            url = f"{base_url}/{idx}"
+            dest = dest_dir / f"file_{idx}.bin"
+            result = await haul_async(
+                url,
+                client,
+                dest=str(dest),
+                state=state,
+                on_progress=on_progress,
+            )
+            progress_counts[idx] = count
+            return result
+
+        async with _make_async_client(async_backend) as client, asyncio.TaskGroup() as tg:
+            for i in range(file_count):
+                tg.create_task(_download_with_progress(client, i))
+
+        assert len(progress_counts) == file_count
+        for idx, count in progress_counts.items():
+            assert count > 0, f"file {idx}: on_progress never called"
+
+    @pytest.mark.anyio
+    async def test_truncation_and_resume_concurrent(
+        self,
+        async_backend: str,
+        multi_file_server: tuple[str, Path, int, int, _ServerFaults],
+    ) -> None:
+        """Server truncates the first request for every file; retry resumes and completes."""
+        base_url, dest_dir, _file_count, file_size, faults = multi_file_server
+        faults.truncate_first_n = 1
+        target_count = 4
+
+        async with _make_async_client(async_backend) as client:
+            results: dict[int, CompleteHaul] = {}
+            async with asyncio.TaskGroup() as tg:
+                for i in range(target_count):
+
+                    async def _download(idx: int = i) -> None:
+                        url = f"{base_url}/{idx}"
+                        dest = dest_dir / f"file_{idx}.bin"
+                        for attempt in range(5):
+                            try:
+                                results[idx] = await haul_async(url, client, dest=str(dest))
+                                break
+                            except PartialHaulError:
+                                assert attempt < 4, f"file {idx}: still partial after 5 attempts"
+
+                    tg.create_task(_download())
+
+        assert len(results) == target_count
+        for i in range(target_count):
+            expected = _deterministic(file_size, seed=i)
+            assert (dest_dir / f"file_{i}.bin").read_bytes() == expected
+            assert results[i].sha256 == _tree_hash(expected)
+
+    @pytest.mark.anyio
+    async def test_repeated_truncation_and_resume(
+        self,
+        async_backend: str,
+        multi_file_server: tuple[str, Path, int, int, _ServerFaults],
+    ) -> None:
+        """Server truncates the first 2 requests per file; multiple resumes converge."""
+        base_url, dest_dir, _file_count, file_size, faults = multi_file_server
+        faults.truncate_first_n = 2
+        target_count = 3
+
+        async with _make_async_client(async_backend) as client:
+            results: dict[int, CompleteHaul] = {}
+            partial_count: dict[int, int] = {}
+            async with asyncio.TaskGroup() as tg:
+                for i in range(target_count):
+
+                    async def _download(idx: int = i) -> None:
+                        url = f"{base_url}/{idx}"
+                        dest = dest_dir / f"file_{idx}.bin"
+                        partials = 0
+                        for attempt in range(10):
+                            try:
+                                results[idx] = await haul_async(url, client, dest=str(dest))
+                                break
+                            except PartialHaulError:
+                                partials += 1
+                                assert attempt < 9, f"file {idx}: still partial after 10 attempts"
+                        partial_count[idx] = partials
+
+                    tg.create_task(_download())
+
+        assert len(results) == target_count
+        for i in range(target_count):
+            expected = _deterministic(file_size, seed=i)
+            assert (dest_dir / f"file_{i}.bin").read_bytes() == expected
+            assert partial_count[i] >= 1, f"file {i}: expected at least 1 PartialHaulError"

--- a/tests/test_live_torture.py
+++ b/tests/test_live_torture.py
@@ -33,19 +33,15 @@ def _get_expected_hash(payload: bytes, block_size: int = 8 * 1024 * 1024) -> str
 # ---------------------------------------------------------------------------
 
 
-def test_short_read_on_206_is_not_complete(http: HttpTest) -> None:
+def test_short_read_on_206_raises_partial(http: HttpTest) -> None:
     """Server sends headers claiming full range, then closes the socket
-    halfway through.  The download must not report CompleteHaul."""
+    halfway through.  Must raise PartialHaulError (not a raw transport exception)."""
     data = deterministic(4 * 1024, seed=3)
     http.serve(data).truncate_206_body_after(len(data) // 2)
 
-    did_raise = False
-    try:
+    with pytest.raises(PartialHaulError):
         http.haul()
-    except Exception:  # noqa: BLE001
-        did_raise = True
 
-    assert did_raise, "truncated 206 should raise, not return CompleteHaul"
     assert not http.dest.exists(), "dest must not exist after truncated 206"
 
 
@@ -54,19 +50,81 @@ def test_short_read_on_206_is_not_complete(http: HttpTest) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_200_truncated_mid_stream_is_not_complete(http: HttpTest) -> None:
-    """Server returns 200 (Range ignored) then closes mid-body."""
+def test_200_truncated_mid_stream_raises_partial(http: HttpTest) -> None:
+    """Server returns 200 (Range ignored) then closes mid-body.
+    Must raise PartialHaulError (not a raw transport exception)."""
     data = deterministic(8 * 1024, seed=5)
     http.serve(data).force_200().truncate_200_body_after(len(data) // 2)
 
-    did_raise = False
-    try:
+    with pytest.raises(PartialHaulError):
         http.haul()
-    except Exception:  # noqa: BLE001
-        did_raise = True
 
-    assert did_raise, "truncated 200 should raise, not return DownloadComplete"
     assert not http.dest.exists()
+
+
+# ---------------------------------------------------------------------------
+# Pathology 2b: Truncate-then-resume round trip (206)
+# ---------------------------------------------------------------------------
+
+
+def test_206_truncation_then_resume_completes(http: HttpTest) -> None:
+    """Server truncates the first request mid-body.  Second call resumes
+    from the checkpoint and completes.  This is the core retry contract:
+    callers only need ``except PartialHaulError``."""
+    data = deterministic(16 * 1024, seed=42)
+    http.serve(data).truncate_206_body_after(len(data) // 2)
+
+    with pytest.raises(PartialHaulError):
+        http.haul()
+
+    assert not http.dest.exists()
+    assert http.part_path.exists(), ".part file should survive for resume"
+
+    # Remove truncation; second call should resume and complete.
+    http._state.truncate_206_body_at = None
+    http.serve(data)
+    result = http.haul()
+    assert isinstance(result, CompleteHaul)
+    assert result.sha256 == _get_expected_hash(data)
+    assert http.output == data
+
+
+def test_206_repeated_truncation_then_resume(http: HttpTest) -> None:
+    """Server truncates the first *two* requests.  Third call succeeds.
+    Validates that the checkpoint advances across multiple partial hauls."""
+    data = deterministic(16 * 1024, seed=99)
+    http.serve(data).truncate_206_body_after(len(data) // 4)
+
+    for _ in range(2):
+        with pytest.raises(PartialHaulError):
+            http.haul()
+        assert not http.dest.exists()
+        assert http.part_path.exists()
+
+    http._state.truncate_206_body_at = None
+    http.serve(data)
+    result = http.haul()
+    assert isinstance(result, CompleteHaul)
+    assert result.sha256 == _get_expected_hash(data)
+    assert http.output == data
+
+
+def test_200_truncation_restarts_from_zero(http: HttpTest) -> None:
+    """When the server ignores Range (200 fallback) and truncates, no
+    checkpoint can be reused — the retry must restart from zero and still
+    complete."""
+    data = deterministic(8 * 1024, seed=77)
+    http.serve(data).force_200().truncate_200_body_after(len(data) // 2)
+
+    with pytest.raises(PartialHaulError):
+        http.haul()
+    assert not http.dest.exists()
+
+    http._state.truncate_200_body_at = None
+    result = http.haul()
+    assert isinstance(result, CompleteHaul)
+    assert result.sha256 == _get_expected_hash(data)
+    assert http.output == data
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Bugfix:** Map mid-stream and pre-stream retryable `TransportError` / `TransportConnectionError` to `PartialHaulError` so callers can rely on a single retry contract across adapters.
- **Perf:** Offload periodic `fdatasync` / checkpoint writes in `haul_async` via the default thread pool executor so the event loop stays responsive.
- **DX:** `justfile` `run_quiet` so quiet linters surface failures; expanded live tests (sync truncation/resume, async concurrency/resume).

Closes #34
Closes #35