### PR TITLE
feat(transport): optional headers, prepare_headers hook, and session proxy

### DIFF
--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -67,7 +67,26 @@ opening any network connection or creating any files.
 
 `haul()` and `haul_async()` auto-detect supported client types and
 wrap them internally via a registry of adapter factories. The adapter
-protocol is deliberately minimal: a single `stream_get()` context manager.
+protocol stays small: [`prepare_headers()`][pyhaul.transport.protocols.TransportSession.prepare_headers]
+(optional policy hook) plus [`stream_get()`][pyhaul.transport.protocols.TransportSession.stream_get].
+
+### Request headers
+
+Before each GET, the engine merges headers in order:
+
+1. **Caller-supplied** — optional `headers=` on [`haul()`][pyhaul.engine.haul] /
+   [`haul_async()`][pyhaul.async_engine.haul_async] (same mapping type the adapters receive).
+2. **Structural defaults** — range negotiation (`Range`, `If-Range` when applicable),
+   plus pyhaul's cache and encoding defaults (`Accept-Encoding`, `Cache-Control`), merged so
+   structural requirements win on conflict.
+3. **Adapter policy** — [`prepare_headers()`][pyhaul.transport.protocols.TransportSession.prepare_headers]
+   receives the merged set as [`TransportHeaders`][pyhaul.transport.types.TransportHeaders]
+   and returns the headers passed to `stream_get`. Built-in adapters use a no-op; custom code
+   can normalize or annotate for tests or telemetry. Removing `Range` / `If-Range` here can
+   break resume — treat those as advanced use only.
+
+For layered debugging or cross-cutting header rules without subclassing every adapter, see
+[Writing a Custom Adapter: session proxy](../guides/custom-transport.md#layering-headers-with-a-session-proxy).
 
 This design means:
 
@@ -76,7 +95,7 @@ This design means:
   pools — everything passes through unchanged.
 - **Transport errors propagate unwrapped.** `httpx.ReadTimeout` stays
   `httpx.ReadTimeout`. You catch the types you already know.
-- **Custom transports are easy.** Implement [`TransportSession`][pyhaul.transport.protocols.TransportSession] (one method)
+- **Custom transports are easy.** Implement [`TransportSession`][pyhaul.transport.protocols.TransportSession] (`prepare_headers` + `stream_get`)
   and register it. See [Writing a Custom Adapter](../guides/custom-transport.md).
 
 For the supported client types and per-adapter notes, see

--- a/docs/guides/adapters.md
+++ b/docs/guides/adapters.md
@@ -39,6 +39,14 @@ pyhaul adds per-request headers for range negotiation (`Range`, `If-Range`,
 modify your session. After `haul()` returns, the session is exactly as you
 left it.
 
+You can also supply **extra headers for that download** via the optional
+`headers=` keyword on [`haul()`][pyhaul.engine.haul] / [`haul_async()`][pyhaul.async_engine.haul_async].
+Those merge before structural headers; structural headers still win where they
+overlap. That is separate from session defaults (which many clients merge in on
+their own). To adjust headers inside the adapter layer — for example tests or
+telemetry — implement or wrap [`prepare_headers()`][pyhaul.transport.protocols.TransportSession.prepare_headers];
+see [Writing a Custom Adapter](custom-transport.md).
+
 ## Per-client examples
 
 ### httpx (sync)

--- a/docs/guides/custom-transport.md
+++ b/docs/guides/custom-transport.md
@@ -1,16 +1,17 @@
 # Writing a Custom Adapter
 
 If your application uses an HTTP library that pyhaul doesn't ship an adapter
-for, you can write your own. The adapter protocol is intentionally minimal: one
-context manager, one iterator.
+for, you can write your own. The adapter protocol is intentionally minimal:
+[`prepare_headers()`][pyhaul.transport.protocols.TransportSession.prepare_headers]
+(opt-in policy) plus one streaming GET context manager.
 
 ## Why the protocol is structured this way
 
 pyhaul needs exactly one thing from an HTTP client: a streaming GET request
 that yields raw bytes. No connection management, no cookie handling, no retry
-logic — just "open a stream, give me bytes, close the stream."
+logic — just "prepare merged headers, open a stream, give me bytes, close the stream."
 
-This is why the protocol is a single `stream_get()` context manager rather than
+This is why the surface area is `prepare_headers` plus `stream_get()` rather than
 a full-featured HTTP client interface. pyhaul delegates everything else
 (auth, proxies, TLS, pooling) to your session.
 
@@ -19,22 +20,35 @@ a full-featured HTTP client interface. pyhaul delegates everything else
 A sync adapter implements [`TransportSession`][pyhaul.transport.protocols.TransportSession]:
 
 ```python
-from contextlib import AbstractContextManager
 from collections.abc import Iterator, Mapping
-from pyhaul.transport.protocols import TransportSession, TransportResponse
-from pyhaul._types import Url
+from contextlib import AbstractContextManager
 
-class TransportSession:
+from pyhaul._types import Url
+from pyhaul.transport.protocols import TransportResponse
+from pyhaul.transport.types import TransportHeaders, TransportRequestOptions
+
+
+class ExampleSyncTransport:
+    """Structural sketch — your adapter must satisfy TransportSession."""
+
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        ...
+
     def stream_get(
         self,
         url: Url,
         *,
         headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
     ) -> AbstractContextManager[TransportResponse]:
         ...
 ```
 
-The returned `TransportResponse` needs three things:
+[`prepare_headers()`][pyhaul.transport.protocols.TransportSession.prepare_headers]
+runs after pyhaul merges caller headers with structural defaults. Return the
+same instance unchanged if you have nothing to adjust.
+
+The returned `TransportResponse` needs four things:
 
 ```python
 class TransportResponse:
@@ -43,6 +57,8 @@ class TransportResponse:
 
     @property
     def headers(self) -> TransportHeaders: ...
+
+    def raise_for_status(self) -> None: ...
 
     def iter_raw_bytes(self, *, chunk_size: int) -> Iterator[bytes]: ...
 ```
@@ -67,7 +83,7 @@ import urllib3
 
 from pyhaul._types import Url
 from pyhaul.transport.protocols import TransportResponse, TransportSession
-from pyhaul.transport.types import TransportHeaders
+from pyhaul.transport.types import TransportHeaders, TransportRequestOptions
 
 
 class MyResponse(TransportResponse):
@@ -99,13 +115,16 @@ class MyAdapter:
     def __init__(self, pool: urllib3.PoolManager) -> None:
         self._pool = pool
 
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        return headers
+
     @contextmanager
     def stream_get(
         self,
         url: Url,
         *,
         headers: Mapping[str, str],
-        options=None,
+        options: TransportRequestOptions | None = None,
     ) -> Iterator[TransportResponse]:
         resp = self._pool.request(
             "GET", str(url), headers=dict(headers), preload_content=False
@@ -139,11 +158,44 @@ to wrap manually.
 
 The async protocol mirrors the sync one:
 
-- [`AsyncTransportSession`][pyhaul.transport.protocols.AsyncTransportSession]`.stream_get()` returns an
+- [`AsyncTransportSession`][pyhaul.transport.protocols.AsyncTransportSession] implements
+  `prepare_headers` and `.stream_get()` returning an
   `AbstractAsyncContextManager[AsyncTransportResponse]`
 - `AsyncTransportResponse.aiter_raw_bytes()` returns an `AsyncIterator[bytes]`
 
 Register with [`register_async_adapter()`][pyhaul._session_dispatch.register_async_adapter].
+
+## Layering headers with a session proxy {#layering-headers-with-a-session-proxy}
+
+If you only need to wrap header preparation — logging, test doubles, or policy —
+without copying an entire adapter, use the fluent builders [`transport_session_proxy()`][pyhaul.transport.proxy_transport_session.transport_session_proxy]
+and [`async_transport_session_proxy()`][pyhaul.transport.proxy_transport_session.async_transport_session_proxy].
+They produce a [`TransportSession`][pyhaul.transport.protocols.TransportSession] /
+[`AsyncTransportSession`][pyhaul.transport.protocols.AsyncTransportSession] that forwards
+`stream_get` to an inner adapter and runs your function **after**
+`inner.prepare_headers`:
+
+```python
+from pyhaul.transport import transport_session_proxy
+from pyhaul.transport.types import TransportHeaders
+
+
+def tag(headers: TransportHeaders) -> TransportHeaders:
+    return headers.with_added("X-Observed", "1")
+
+
+inner = MyAdapter(pool)
+wrapped = (
+    transport_session_proxy()
+    .around(inner)
+    .preparing_headers_with(tag)
+    .build()
+)
+
+result = haul(url, wrapped, dest="file.bin")
+```
+
+See also the [TransportHeaders](../reference/headers.md) reference page and the [API summary](../reference/api.md#transport-headers-type).
 
 ## TransportHeaders
 
@@ -160,7 +212,8 @@ headers = TransportHeaders.from_pairs([
 ])
 ```
 
-This handles case-insensitive lookups and multi-value headers.
+This handles case-insensitive lookups and multi-value headers. The same type is
+used on the request path after merging (see [TransportHeaders](../reference/headers.md)).
 
 ## Error mapping (optional but recommended)
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -32,10 +32,11 @@
     options:
       heading_level: 3
 
-::: pyhaul.transport._headers.TransportHeaders
-    options:
-      heading_level: 3
-      members: false
+### TransportHeaders {#transport-headers-type}
+
+The immutable header type used for normalized responses and for merged outbound
+requests inside adapters. Full constructors and methods are documented on the
+dedicated [TransportHeaders](headers.md) page — duplicated here it would collide with that reference.
 
 ## Utility functions
 
@@ -76,5 +77,17 @@
       heading_level: 3
 
 ::: pyhaul.transport.protocols.AsyncTransportResponse
+    options:
+      heading_level: 3
+
+## Transport session proxy
+
+Layer header policy around an existing adapter without subclassing each backend:
+
+::: pyhaul.transport.proxy_transport_session.transport_session_proxy
+    options:
+      heading_level: 3
+
+::: pyhaul.transport.proxy_transport_session.async_transport_session_proxy
     options:
       heading_level: 3

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,7 +7,9 @@ It requires at least one HTTP client extra to be installed.
     The CLI exists for demonstration and quick smoke-testing. It is **not**
     intended for scripting or automation. Options, output format, and exit
     code semantics may change at any time without notice. For programmatic
-    use, depend on the [`haul()`][pyhaul.engine.haul] / [`haul_async()`][pyhaul.async_engine.haul_async] Python API instead.
+    use, depend on the [`haul()`][pyhaul.engine.haul] /
+    [`haul_async()`][pyhaul.async_engine.haul_async] Python API instead (including the optional
+    `headers=` keyword, which mirrors `-H` / `-A` here).
 
 ## Usage
 

--- a/docs/reference/headers.md
+++ b/docs/reference/headers.md
@@ -1,9 +1,17 @@
 # TransportHeaders
 
-Immutable, case-insensitive, multi-value HTTP response headers.
-`TransportHeaders` is attached to
-[`UnexpectedStatusError`][pyhaul._types.UnexpectedStatusError] and available on
-every transport response — you never need to construct one yourself.
+Immutable, case-insensitive, multi-value HTTP headers used throughout the transport
+layer. Most callers encounter them as **response** metadata:
+[`UnexpectedStatusError`][pyhaul._types.UnexpectedStatusError] carries them, and every
+[`TransportResponse`][pyhaul.transport.protocols.TransportResponse] exposes normalized
+response headers.
+
+On the **request** path, pyhaul also represents the merged outbound header set as
+`TransportHeaders`: user headers plus structural defaults, then the result of
+[`prepare_headers()`][pyhaul.transport.protocols.TransportSession.prepare_headers] before
+your adapter's HTTP client sees them. You rarely construct request-side instances yourself;
+[`haul()`][pyhaul.engine.haul] / [`haul_async()`][pyhaul.async_engine.haul_async] accept an
+optional plain mapping for extras.
 
 ## Quick usage
 

--- a/src/pyhaul/_engine_common.py
+++ b/src/pyhaul/_engine_common.py
@@ -13,6 +13,7 @@ import hashlib
 import logging
 import os
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -39,7 +40,7 @@ from pyhaul.persist import (
     ctrl_path_for,
     write_atomic,
 )
-from pyhaul.transport.types import TransportHeaders
+from pyhaul.transport._headers import TransportHeaders
 
 DEFAULT_CHUNK = 1 << 16  # 64 KiB
 DEFAULT_FLUSH = 1 << 20  # 1 MiB
@@ -70,7 +71,7 @@ class PrepareHaul:
     tail_hash: bytes | None
     block_size: int
     request_byte: int
-    merged_headers: dict[str, str]
+    merged_headers: TransportHeaders
     t0: float
 
 
@@ -91,7 +92,12 @@ class StreamPlan:
 # ─── Preparation ──────────────────────────────────────────────────
 
 
-def prepare_haul(url: str, dest: str | Path) -> PrepareHaul:
+def prepare_haul(
+    url: str,
+    dest: str | Path,
+    *,
+    user_headers: Mapping[str, str] | None = None,
+) -> PrepareHaul:
     """Read checkpoint, build request headers, return immutable context."""
     t0 = time.monotonic()
     dest_path = Path(dest)
@@ -121,7 +127,9 @@ def prepare_haul(url: str, dest: str | Path) -> PrepareHaul:
     req_hdrs: dict[str, str] = {"Range": f"bytes={request_byte}-"}
     if stored_etag:
         req_hdrs["If-Range"] = str(stored_etag)
-    merged = merge_headers({}, {**DEFAULT_HEADERS, **req_hdrs})
+
+    merged = merge_headers(dict(user_headers or {}), {**DEFAULT_HEADERS, **req_hdrs})
+    th = TransportHeaders.from_mapping(merged)
 
     logger.debug(
         "Prepared download request",
@@ -145,7 +153,7 @@ def prepare_haul(url: str, dest: str | Path) -> PrepareHaul:
         tail_hash=tail_hash,
         block_size=block_size,
         request_byte=request_byte,
-        merged_headers=merged,
+        merged_headers=th,
         t0=t0,
     )
 

--- a/src/pyhaul/async_engine.py
+++ b/src/pyhaul/async_engine.py
@@ -15,7 +15,7 @@ import asyncio
 import contextlib
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 
 from pyhaul._engine_common import (
@@ -50,6 +50,7 @@ async def haul_async(
     client: AsyncTransportSession | object,
     *,
     dest: str | Path,
+    headers: Mapping[str, str] | None = None,
     state: HaulState | None = None,
     chunk_size: int = DEFAULT_CHUNK,
     flush_every: int = DEFAULT_FLUSH,
@@ -62,6 +63,8 @@ async def haul_async(
 
     *url* is validated on entry; invalid schemes or missing hosts raise
     :class:`ValueError`.
+
+    *headers*, when provided, are merged with pyhaul's structural requirements.
 
     *state*, when provided, is a :class:`HaulState` updated in-place
     throughout the download — always accurate regardless of how the
@@ -79,11 +82,15 @@ async def haul_async(
     if state is None:
         state = HaulState()
     transport = coerce_async_session(client)
-    prep = prepare_haul(url, dest)
+
+    prep = prepare_haul(url, dest, user_headers=headers)
+    prepare_fn = getattr(transport, "prepare_headers", None)
+    final_headers = prepare_fn(prep.merged_headers) if prepare_fn else prep.merged_headers
+
     loop = asyncio.get_running_loop()
 
     try:
-        async with transport.stream_get(prep.parsed_url, headers=prep.merged_headers) as resp:
+        async with transport.stream_get(prep.parsed_url, headers=final_headers) as resp:
             action = handle_response(resp.status_code, resp.headers, prep, state)
 
             if not isinstance(action, StreamPlan):

--- a/src/pyhaul/cli.py
+++ b/src/pyhaul/cli.py
@@ -498,8 +498,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         return EXIT_ERROR
 
     client = _build_client(args)
+    headers = dict(args.header)
+    if args.user_agent:
+        headers["User-Agent"] = args.user_agent
+
     try:
-        return _download_loop(url, client, dest, printer)
+        return _download_loop(url, client, dest, printer, headers=headers)
     finally:
         _close_client(client)
 
@@ -509,6 +513,8 @@ def _download_loop(  # noqa: C901, PLR0911
     client: object,
     dest: Path,
     printer: Printer,
+    *,
+    headers: dict[str, str],
 ) -> int:
     interrupt = _InterruptState()
     _install_signal_handlers(interrupt)
@@ -526,7 +532,7 @@ def _download_loop(  # noqa: C901, PLR0911
         state.bytes_read = 0
 
         try:
-            result = _run_haul(dest, client, url, state)
+            result = _run_haul(dest, client, url, state, headers=headers)
         except PartialHaulError as exc:
             printer.info(f"partial (attempt {attempt}/{_MAX_RETRIES}): {exc.reason}; resuming…")
             if state.bytes_read == 0:
@@ -569,11 +575,12 @@ def _run_haul(
     client: object,
     url: str,
     state: HaulState,
+    headers: dict[str, str],
 ) -> CompleteHaul:
     """Call engine.haul.  Exceptions propagate to the caller."""
     from pyhaul.engine import haul
 
-    return haul(url, client, dest=dest, state=state)
+    return haul(url, client, dest=dest, state=state, headers=headers)
 
 
 def _print_err(msg: str) -> None:

--- a/src/pyhaul/engine.py
+++ b/src/pyhaul/engine.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 
 from pyhaul._engine_common import (
@@ -37,6 +37,7 @@ def haul(
     client: TransportSession | object,
     *,
     dest: str | Path,
+    headers: Mapping[str, str] | None = None,
     state: HaulState | None = None,
     chunk_size: int = DEFAULT_CHUNK,
     flush_every: int = DEFAULT_FLUSH,
@@ -49,6 +50,8 @@ def haul(
 
     *url* is validated on entry; invalid schemes or missing hosts raise
     :class:`ValueError`.
+
+    *headers*, when provided, are merged with pyhaul's structural requirements.
 
     *state*, when provided, is a :class:`HaulState` updated in-place
     throughout the download — always accurate regardless of how the
@@ -66,10 +69,13 @@ def haul(
     if state is None:
         state = HaulState()
     transport = coerce_sync_session(client)
-    prep = prepare_haul(url, dest)
+
+    prep = prepare_haul(url, dest, user_headers=headers)
+    prepare_fn = getattr(transport, "prepare_headers", None)
+    final_headers = prepare_fn(prep.merged_headers) if prepare_fn else prep.merged_headers
 
     try:
-        with transport.stream_get(prep.parsed_url, headers=prep.merged_headers) as resp:
+        with transport.stream_get(prep.parsed_url, headers=final_headers) as resp:
             action = handle_response(resp.status_code, resp.headers, prep, state)
 
             if not isinstance(action, StreamPlan):

--- a/src/pyhaul/transport/__init__.py
+++ b/src/pyhaul/transport/__init__.py
@@ -13,11 +13,21 @@ from pyhaul.transport.protocols import (
     TransportResponse,
     TransportSession,
 )
+from pyhaul.transport.proxy_transport_session import (
+    AsyncTransportSessionProxyPlanning,
+    AsyncTransportSessionProxyRecipe,
+    TransportSessionProxyPlanning,
+    TransportSessionProxyRecipe,
+    async_transport_session_proxy,
+    transport_session_proxy,
+)
 from pyhaul.transport.types import TransportHeaders, TransportRequestOptions
 
 __all__ = [
     "AsyncTransportResponse",
     "AsyncTransportSession",
+    "AsyncTransportSessionProxyPlanning",
+    "AsyncTransportSessionProxyRecipe",
     "TransportConnectionError",
     "TransportError",
     "TransportHTTPError",
@@ -25,6 +35,10 @@ __all__ = [
     "TransportRequestOptions",
     "TransportResponse",
     "TransportSession",
+    "TransportSessionProxyPlanning",
+    "TransportSessionProxyRecipe",
     "TransportTLSError",
     "TransportUnsupportedError",
+    "async_transport_session_proxy",
+    "transport_session_proxy",
 ]

--- a/src/pyhaul/transport/aiohttp_adapter.py
+++ b/src/pyhaul/transport/aiohttp_adapter.py
@@ -148,6 +148,10 @@ class AsyncAiohttpAdapter:
     def __init__(self, session: aiohttp.ClientSession) -> None:
         self._session = session
 
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        """Optionally mutate headers before they are sent (noop)."""
+        return headers
+
     @asynccontextmanager
     async def stream_get(
         self,

--- a/src/pyhaul/transport/httpx_adapter.py
+++ b/src/pyhaul/transport/httpx_adapter.py
@@ -127,6 +127,10 @@ class HttpxAdapter:
     def __init__(self, client: httpx.Client) -> None:
         self._client = client
 
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        """Optionally mutate headers before they are sent (noop)."""
+        return headers
+
     @contextmanager
     def stream_get(
         self,
@@ -194,6 +198,10 @@ class AsyncHttpxAdapter:
 
     def __init__(self, client: httpx.AsyncClient) -> None:
         self._client = client
+
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        """Optionally mutate headers before they are sent (noop)."""
+        return headers
 
     @asynccontextmanager
     async def stream_get(

--- a/src/pyhaul/transport/niquests_adapter.py
+++ b/src/pyhaul/transport/niquests_adapter.py
@@ -82,6 +82,10 @@ class NiquestsAdapter:
     def __init__(self, session: niquests.Session) -> None:
         self._session = session
 
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        """Optionally mutate headers before they are sent (noop)."""
+        return headers
+
     @contextmanager
     def stream_get(
         self,
@@ -149,6 +153,10 @@ class AsyncNiquestsAdapter:
 
     def __init__(self, session: niquests.AsyncSession) -> None:
         self._session = session
+
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        """Optionally mutate headers before they are sent (noop)."""
+        return headers
 
     @asynccontextmanager
     async def stream_get(

--- a/src/pyhaul/transport/protocols.py
+++ b/src/pyhaul/transport/protocols.py
@@ -51,7 +51,20 @@ class TransportResponse(Protocol):
 
 @runtime_checkable
 class TransportSession(Protocol):
-    """Sync session: one method (``stream_get``), no lifecycle, no mutation."""
+    """Sync transport: ``prepare_headers`` then ``stream_get``; no lifecycle ownership."""
+
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        """Optionally mutate headers before they are sent.
+
+        The engine calls this after merging user headers and pyhaul structural
+        requirements.  Adapters can use this to suppress headers (e.g. for
+        conformance testing) or add session-specific metadata.
+
+        .. warning::
+           Removing structural headers like ``Range`` or ``If-Range`` may
+           break pyhaul's resume logic.
+        """
+        ...
 
     # CPD-OFF: mirror AsyncTransportSession; keep protocols flat (no inheritance)
     def stream_get(
@@ -79,7 +92,7 @@ class AsyncTransportResponse(Protocol):
     # CPD-OFF: mirror TransportResponse; keep protocols flat (no inheritance)
     @property
     def status_code(self) -> int:
-        """HTTP status line code (e.g. 200, 206, 416)."""
+        """HTTP status code of the response."""
         ...
 
     @property
@@ -100,7 +113,11 @@ class AsyncTransportResponse(Protocol):
 
 @runtime_checkable
 class AsyncTransportSession(Protocol):
-    """Async equivalent of :class:`TransportSession`."""
+    """Async transport: ``prepare_headers`` then ``stream_get`` (async context manager)."""
+
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        """Optionally mutate headers before they are sent (see sync version)."""
+        ...
 
     # CPD-OFF: mirror TransportSession; keep protocols flat (no inheritance)
     def stream_get(

--- a/src/pyhaul/transport/proxy_transport_session.py
+++ b/src/pyhaul/transport/proxy_transport_session.py
@@ -1,0 +1,191 @@
+"""Faithful proxies around transport sessions with a staged, fluent factory.
+
+Chains read left-to-right as imperative steps, e.g.::
+
+    transport_session_proxy().around(adapter).preparing_headers_with(strip_noise).build()
+
+The staging model omits impossible sequences: you cannot chain a second ``.around()`` on
+the recipe type, and ``.build()`` is unavailable until ``.around(inner)`` has run
+(different public types per stage encode this without extra ``TypeVar`` ceremony).
+
+``preparing_headers_with`` chains **after** the inner session's
+:meth:`~pyhaul.transport.protocols.TransportSession.prepare_headers` (outer wins for
+telemetry and conformance policy).
+
+**With downloads** (``coerce_sync_session`` / ``haul``): ``.around()`` takes an existing
+:class:`~pyhaul.transport.protocols.TransportSession` — adapt a raw HTTP client with the
+adapter registry or explicit adapter constructors first, wrap with this builder, then pass
+the result to ``haul``. Built proxies satisfy the protocol, so coercion **passes them
+through** without re-running reflective dispatch; forwarded calls delegate to ``inner``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable, Mapping
+from contextlib import AbstractContextManager, asynccontextmanager
+from dataclasses import dataclass
+from typing import Self, final
+
+from pyhaul._types import Url
+from pyhaul.transport.protocols import (
+    AsyncTransportResponse,
+    AsyncTransportSession,
+    TransportResponse,
+    TransportSession,
+)
+from pyhaul.transport.types import TransportHeaders, TransportRequestOptions
+
+# ---------------------------------------------------------------------------
+# Outer header hook applied after inner.prepare_headers(...)
+# ---------------------------------------------------------------------------
+
+type OuterPrepareHeaders = Callable[[TransportHeaders], TransportHeaders]
+
+# ─── Pending: must call .around() before anything else ─────────────────────
+
+
+class TransportSessionProxyPlanning:
+    """First stage — ``around(inner)`` is required before shaping headers or ``build()``."""
+
+    __slots__ = ()
+
+    def around(self, inner: TransportSession) -> TransportSessionProxyRecipe:
+        """Bind the delegate session that receives forwarded calls (reads: *proxy around this session*)."""
+        return TransportSessionProxyRecipe(inner=inner)
+
+
+class AsyncTransportSessionProxyPlanning:
+    """Async first stage — ``around(inner)`` is required before shaping headers or ``build()``."""
+
+    __slots__ = ()
+
+    def around(self, inner: AsyncTransportSession) -> AsyncTransportSessionProxyRecipe:
+        """Bind the delegate async session (reads: *proxy around this async session*)."""
+        return AsyncTransportSessionProxyRecipe(inner=inner)
+
+
+# ─── Recipe: optional header layering, then build ───────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class TransportSessionProxyRecipe:
+    """Session is bound — optionally layer header policy, then :meth:`build`."""
+
+    inner: TransportSession
+    outer_prepare_headers: OuterPrepareHeaders | None = None
+
+    def preparing_headers_with(self, outer: OuterPrepareHeaders) -> Self:
+        """Layer an outer transformation after ``inner.prepare_headers`` (*last call wins if chained*)."""
+        return type(self)(
+            inner=self.inner,
+            outer_prepare_headers=outer,
+        )
+
+    def build(self) -> TransportSession:
+        """Produce the forwarding :class:`~pyhaul.transport.protocols.TransportSession` instance."""
+        return _ProxiedTransportSession(
+            inner=self.inner,
+            outer_prepare_headers=self.outer_prepare_headers,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AsyncTransportSessionProxyRecipe:
+    """Async session is bound — optionally layer header policy, then :meth:`build`."""
+
+    inner: AsyncTransportSession
+    outer_prepare_headers: OuterPrepareHeaders | None = None
+
+    def preparing_headers_with(self, outer: OuterPrepareHeaders) -> Self:
+        """Layer an outer transformation after ``inner.prepare_headers`` (*last wins if chained*)."""
+        return type(self)(
+            inner=self.inner,
+            outer_prepare_headers=outer,
+        )
+
+    def build(self) -> AsyncTransportSession:
+        """Produce the forwarding async transport session."""
+        return _ProxiedAsyncTransportSession(
+            inner=self.inner,
+            outer_prepare_headers=self.outer_prepare_headers,
+        )
+
+
+@final
+class _ProxiedTransportSession:
+    """Delegates ``stream_get`` faithfully; optionally layers ``prepare_headers`` after inner."""
+
+    __slots__ = ("_inner", "_outer_prepare_headers")
+
+    def __init__(
+        self,
+        *,
+        inner: TransportSession,
+        outer_prepare_headers: OuterPrepareHeaders | None,
+    ) -> None:
+        self._inner = inner
+        self._outer_prepare_headers = outer_prepare_headers
+
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        prepared = self._inner.prepare_headers(headers)
+        outer = self._outer_prepare_headers
+        return prepared if outer is None else outer(prepared)
+
+    def stream_get(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AbstractContextManager[TransportResponse]:
+        return self._inner.stream_get(url, headers=headers, options=options)
+
+
+@final
+class _ProxiedAsyncTransportSession:
+    __slots__ = ("_inner", "_outer_prepare_headers")
+
+    def __init__(
+        self,
+        *,
+        inner: AsyncTransportSession,
+        outer_prepare_headers: OuterPrepareHeaders | None,
+    ) -> None:
+        self._inner = inner
+        self._outer_prepare_headers = outer_prepare_headers
+
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        prepared = self._inner.prepare_headers(headers)
+        outer = self._outer_prepare_headers
+        return prepared if outer is None else outer(prepared)
+
+    @asynccontextmanager
+    async def stream_get(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AsyncIterator[AsyncTransportResponse]:
+        async with self._inner.stream_get(url, headers=headers, options=options) as resp:
+            yield resp
+
+
+def transport_session_proxy() -> TransportSessionProxyPlanning:
+    """Start a fluent chain for wrapping a synchronous :class:`TransportSession`."""
+    return TransportSessionProxyPlanning()
+
+
+def async_transport_session_proxy() -> AsyncTransportSessionProxyPlanning:
+    """Start a fluent chain for wrapping an :class:`AsyncTransportSession`."""
+    return AsyncTransportSessionProxyPlanning()
+
+
+__all__ = [
+    "AsyncTransportSessionProxyPlanning",
+    "AsyncTransportSessionProxyRecipe",
+    "TransportSessionProxyPlanning",
+    "TransportSessionProxyRecipe",
+    "async_transport_session_proxy",
+    "transport_session_proxy",
+]

--- a/src/pyhaul/transport/requests_adapter.py
+++ b/src/pyhaul/transport/requests_adapter.py
@@ -66,6 +66,10 @@ class RequestsAdapter:
     def __init__(self, session: requests.Session) -> None:
         self._session = session
 
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        """Optionally mutate headers before they are sent (noop)."""
+        return headers
+
     @contextmanager
     def stream_get(
         self,

--- a/src/pyhaul/transport/urllib3_adapter.py
+++ b/src/pyhaul/transport/urllib3_adapter.py
@@ -126,6 +126,10 @@ class Urllib3Adapter:
     def __init__(self, pool: urllib3.PoolManager) -> None:
         self._pool = pool
 
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        """Optionally mutate headers before they are sent (noop)."""
+        return headers
+
     @contextmanager
     def stream_get(
         self,

--- a/tests/test_async_engine.py
+++ b/tests/test_async_engine.py
@@ -62,6 +62,9 @@ class AsyncMockSession:
         self.requests: list[dict[str, object]] = []
         self._call_index = 0
 
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        return headers
+
     def add_response(self, resp: AsyncMockResponse) -> None:
         self.responses.append(resp)
 
@@ -73,7 +76,7 @@ class AsyncMockSession:
         headers: Mapping[str, str],
         options: TransportRequestOptions | None = None,
     ) -> AsyncIterator[AsyncTransportResponse]:
-        self.requests.append({"url": url, "headers": dict(headers), "options": options})
+        self.requests.append({"url": url, "headers": headers, "options": options})
         idx = self._call_index
         self._call_index += 1
         if idx >= len(self.responses):
@@ -175,7 +178,7 @@ class TestAsyncFresh206KnownTotal:
         await haul_async(_TEST_URL, session, dest=str(dest))
 
         req_headers = session.requests[0]["headers"]
-        assert isinstance(req_headers, dict)
+        assert isinstance(req_headers, TransportHeaders)
         assert req_headers["Range"] == "bytes=0-"
 
 
@@ -255,7 +258,7 @@ class TestAsyncResume206:
         assert dest.read_bytes() == full_body
 
         req_headers = session.requests[0]["headers"]
-        assert isinstance(req_headers, dict)
+        assert isinstance(req_headers, TransportHeaders)
         assert req_headers["Range"] == "bytes=5-"
         assert req_headers["If-Range"] == '"test"'
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -292,7 +292,7 @@ class TestMainMissingBackend:
 
 class TestMainSuccessfulDownload:
     def test_success_returns_zero(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        def mock_haul(dest: Path, client: object, url: str, state: HaulState) -> CompleteHaul:
+        def mock_haul(dest: Path, client: object, url: str, state: HaulState, headers: dict[str, str]) -> CompleteHaul:
             state.valid_length = 1024
             return _make_complete_haul()
 
@@ -306,7 +306,7 @@ class TestMainPartialHaul:
     def test_partial_retries_then_gives_up(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         call_count = 0
 
-        def mock_haul(dest: Path, client: object, url: str, state: HaulState) -> CompleteHaul:
+        def mock_haul(dest: Path, client: object, url: str, state: HaulState, headers: dict[str, str]) -> CompleteHaul:
             nonlocal call_count
             call_count += 1
             raise PartialHaulError("truncated")
@@ -322,7 +322,7 @@ class TestMainPartialHaul:
 
 class TestMainHaulError:
     def test_haul_error_returns_one(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        def mock_haul(dest: Path, client: object, url: str, state: HaulState) -> CompleteHaul:
+        def mock_haul(dest: Path, client: object, url: str, state: HaulState, headers: dict[str, str]) -> CompleteHaul:
             raise HaulError("bad")
 
         monkeypatch.setattr("pyhaul.cli._run_haul", mock_haul)
@@ -333,7 +333,7 @@ class TestMainHaulError:
 
 class TestMainServerMisconfigured:
     def test_server_misconfigured_returns_one(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        def mock_haul(dest: Path, client: object, url: str, state: HaulState) -> CompleteHaul:
+        def mock_haul(dest: Path, client: object, url: str, state: HaulState, headers: dict[str, str]) -> CompleteHaul:
             raise ServerMisconfiguredError("no ranges")
 
         monkeypatch.setattr("pyhaul.cli._run_haul", mock_haul)
@@ -344,7 +344,7 @@ class TestMainServerMisconfigured:
 
 class TestMainUnexpectedStatus:
     def test_unexpected_status_returns_one(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        def mock_haul(dest: Path, client: object, url: str, state: HaulState) -> CompleteHaul:
+        def mock_haul(dest: Path, client: object, url: str, state: HaulState, headers: dict[str, str]) -> CompleteHaul:
             raise UnexpectedStatusError(429, TransportHeaders.from_pairs([("Retry-After", "60")]))
 
         monkeypatch.setattr("pyhaul.cli._run_haul", mock_haul)
@@ -355,7 +355,7 @@ class TestMainUnexpectedStatus:
 
 class TestMainNetworkError:
     def test_connection_error_returns_one(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        def mock_haul(dest: Path, client: object, url: str, state: HaulState) -> CompleteHaul:
+        def mock_haul(dest: Path, client: object, url: str, state: HaulState, headers: dict[str, str]) -> CompleteHaul:
             raise ConnectionError("refused")
 
         monkeypatch.setattr("pyhaul.cli._run_haul", mock_haul)
@@ -364,7 +364,7 @@ class TestMainNetworkError:
         assert result == 1
 
     def test_os_error_returns_one(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        def mock_haul(dest: Path, client: object, url: str, state: HaulState) -> CompleteHaul:
+        def mock_haul(dest: Path, client: object, url: str, state: HaulState, headers: dict[str, str]) -> CompleteHaul:
             raise OSError("disk full")
 
         monkeypatch.setattr("pyhaul.cli._run_haul", mock_haul)
@@ -377,7 +377,7 @@ class TestMainQuiet:
     def test_quiet_suppresses_progress(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        def mock_haul(dest: Path, client: object, url: str, state: HaulState) -> CompleteHaul:
+        def mock_haul(dest: Path, client: object, url: str, state: HaulState, headers: dict[str, str]) -> CompleteHaul:
             state.valid_length = 1024
             return _make_complete_haul()
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -64,6 +64,9 @@ class MockSession:
         self.requests: list[dict[str, object]] = []
         self._call_index = 0
 
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        return headers
+
     def add_response(self, resp: MockResponse) -> None:
         self.responses.append(resp)
 
@@ -75,7 +78,7 @@ class MockSession:
         headers: Mapping[str, str],
         options: TransportRequestOptions | None = None,
     ) -> Iterator[TransportResponse]:
-        self.requests.append({"url": url, "headers": dict(headers), "options": options})
+        self.requests.append({"url": url, "headers": headers, "options": options})
         idx = self._call_index
         self._call_index += 1
         if idx >= len(self.responses):
@@ -174,7 +177,7 @@ class TestFreshDownload206KnownTotal:
 
         assert len(session.requests) == 1
         req_headers = session.requests[0]["headers"]
-        assert isinstance(req_headers, dict)
+        assert isinstance(req_headers, TransportHeaders)
         assert "Range" in req_headers
         assert req_headers["Range"] == "bytes=0-"
 
@@ -252,7 +255,7 @@ class TestResume206:
         assert dest.read_bytes() == full_body
 
         req_headers = session.requests[0]["headers"]
-        assert isinstance(req_headers, dict)
+        assert isinstance(req_headers, TransportHeaders)
         assert req_headers["Range"] == "bytes=5-"
         assert req_headers["If-Range"] == '"test"'
 
@@ -415,7 +418,7 @@ class TestResumeNoEtag:
         assert dest.read_bytes() == full_body
 
         req_headers = session.requests[0]["headers"]
-        assert isinstance(req_headers, dict)
+        assert isinstance(req_headers, TransportHeaders)
         assert req_headers["Range"] == "bytes=3-"
         assert "If-Range" not in req_headers
 

--- a/tests/test_integrity_validation.py
+++ b/tests/test_integrity_validation.py
@@ -38,6 +38,9 @@ class MockSession:
         self.requests: list[dict[str, object]] = []
         self._call_index = 0
 
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        return headers
+
     def add_response(self, resp: MockResponse) -> None:
         self.responses.append(resp)
 

--- a/tests/test_proxy_transport_session.py
+++ b/tests/test_proxy_transport_session.py
@@ -1,0 +1,198 @@
+"""Transport session proxy fluent builder."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator, Mapping
+from contextlib import asynccontextmanager, contextmanager
+
+from pyhaul._types import Url, parse_url
+from pyhaul.transport.protocols import (
+    AsyncTransportSession,
+    TransportResponse,
+    TransportSession,
+)
+from pyhaul.transport.proxy_transport_session import (
+    AsyncTransportSessionProxyPlanning,
+    TransportSessionProxyPlanning,
+    async_transport_session_proxy,
+    transport_session_proxy,
+)
+from pyhaul.transport.types import TransportHeaders, TransportRequestOptions
+
+
+class StubResponse(TransportResponse):
+    def __init__(self) -> None:
+        self._hdrs = TransportHeaders.build()
+
+    @property
+    def status_code(self) -> int:
+        return 200
+
+    @property
+    def headers(self) -> TransportHeaders:
+        return self._hdrs
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def iter_raw_bytes(self, *, chunk_size: int) -> Iterator[bytes]:
+        yield b""
+
+
+class StubTransport(TransportSession):
+    """Minimal structural session for proxy tests."""
+
+    def __init__(self) -> None:
+        self.prepared_sequence: list[TransportHeaders] = []
+        self.stream_get_calls = 0
+
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        self.prepared_sequence.append(headers)
+        return headers.with_added("X-Inner", "1")
+
+    @contextmanager
+    def stream_get(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> Iterator[StubResponse]:
+        self.stream_get_calls += 1
+        yield StubResponse()
+
+
+def test_transport_session_proxy_chain_order() -> None:
+    inner = StubTransport()
+    calls: list[str] = []
+
+    def outer(h: TransportHeaders) -> TransportHeaders:
+        calls.append("outer")
+        assert h["X-Inner"] == "1"
+        return h.with_added("X-Outer", "2")
+
+    proxy = transport_session_proxy().around(inner).preparing_headers_with(outer).build()
+    th = TransportHeaders.build(Accept="*/*")
+
+    got = proxy.prepare_headers(th)
+
+    assert got["Accept"] == "*/*"
+    assert got["X-Inner"] == "1"
+    assert got["X-Outer"] == "2"
+    assert calls == ["outer"]
+    assert len(inner.prepared_sequence) == 1
+
+
+def test_build_without_outer_prepare_forwards_prepare_headers_only() -> None:
+    inner = StubTransport()
+    proxy = transport_session_proxy().around(inner).build()
+    got = proxy.prepare_headers(TransportHeaders.build())
+    assert got["X-Inner"] == "1"
+
+
+def test_stream_get_forwarded_but_not_called_during_prepare_only() -> None:
+    inner = StubTransport()
+    proxy = transport_session_proxy().around(inner).build()
+    proxy.prepare_headers(TransportHeaders.build())
+
+    assert inner.stream_get_calls == 0
+
+
+def test_transport_session_proxy_returns_planning_stage() -> None:
+    p = transport_session_proxy()
+    assert isinstance(p, TransportSessionProxyPlanning)
+
+
+def test_planning_stage_has_no_build() -> None:
+    pending = transport_session_proxy()
+    assert not hasattr(pending, "build")
+
+
+def test_recipe_stage_has_no_around_second_inner_unrepresentable_by_types() -> None:
+    inner = StubTransport()
+    recipe = transport_session_proxy().around(inner)
+
+    assert not hasattr(recipe, "around")
+
+
+def test_outer_last_call_wins() -> None:
+    inner = StubTransport()
+
+    proxy = (
+        transport_session_proxy()
+        .around(inner)
+        .preparing_headers_with(lambda h: h.with_added("X", "a"))
+        .preparing_headers_with(lambda h: h.with_added("X", "b"))
+        .build()
+    )
+    built = proxy.prepare_headers(TransportHeaders.build())
+
+    assert built["X"] == "b"
+
+
+class _MiniAsyncResp:
+    def __init__(self) -> None:
+        self._h = TransportHeaders.build()
+
+    @property
+    def status_code(self) -> int:
+        return 200
+
+    @property
+    def headers(self) -> TransportHeaders:
+        return self._h
+
+    def raise_for_status(self) -> None:
+        pass
+
+    async def aiter_raw_bytes(self, *, chunk_size: int) -> AsyncIterator[bytes]:
+        if False:
+            yield b""
+
+
+class AsyncStubTransport(AsyncTransportSession):
+    def __init__(self) -> None:
+        self.prepared: list[TransportHeaders] = []
+
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        self.prepared.append(headers)
+        return headers.with_added("Y-Inner", "1")
+
+    @asynccontextmanager
+    async def stream_get(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AsyncIterator[_MiniAsyncResp]:
+        yield _MiniAsyncResp()
+
+
+def test_async_transport_session_proxy_prepare_order() -> None:
+    inner = AsyncStubTransport()
+
+    def outer(h: TransportHeaders) -> TransportHeaders:
+        return h.with_added("Y-Outer", "2")
+
+    proxy = async_transport_session_proxy().around(inner).preparing_headers_with(outer).build()
+    got = proxy.prepare_headers(TransportHeaders.build())
+
+    assert got["Y-Inner"] == "1"
+    assert got["Y-Outer"] == "2"
+
+
+def test_async_planning_is_distinct_type() -> None:
+    p = async_transport_session_proxy()
+    assert isinstance(p, AsyncTransportSessionProxyPlanning)
+
+
+def test_stream_get_forwards_to_inner() -> None:
+    inner = StubTransport()
+    proxy = transport_session_proxy().around(inner).build()
+    u = parse_url("http://example.test/file")
+
+    with proxy.stream_get(u, headers={"Accept": "*/*"}) as resp:
+        assert resp.status_code == 200
+
+    assert inner.stream_get_calls == 1


### PR DESCRIPTION
## Summary

Adds optional per-download HTTP headers on `haul()` / `haul_async()`, merged with pyhaul structural defaults before each GET.

Introduces `TransportSession.prepare_headers` (and async analogue); built-in adapters are pass-through. The engine invokes `prepare_headers` after merge when present.

Adds fluent `transport_session_proxy()` / `async_transport_session_proxy()` to wrap adapters with layered outer header transforms (after inner `prepare_headers`), plus tests.

CLI forwards `-H` / `--header` and `--user-agent` into `haul(..., headers=...)`.

MkDocs updated for adapter pipeline, custom transport, API reference, headers, and CLI.