### PR TITLE
fix(session): thread-safe adapter registry with lock and tuple COW

### DIFF
--- a/src/pyhaul/_session_dispatch.py
+++ b/src/pyhaul/_session_dispatch.py
@@ -5,13 +5,14 @@ packages can register additional adapters via :func:`register_sync_adapter`
 and :func:`register_async_adapter` — no monkeypatching required.
 
 Each adapter factory is a callable ``(object) -> T | None``.  The dispatch
-walks the factory list in registration order; the first non-``None`` result
+walks the factory tuple in registration order; the first non-``None`` result
 wins.  Built-in factories use lazy imports so no backend is pulled until a
 matching client object actually arrives.
 """
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Callable
 
 from pyhaul.transport.protocols import AsyncTransportSession, TransportSession
@@ -113,21 +114,23 @@ def _try_async_aiohttp(obj: object) -> AsyncTransportSession | None:
 
 
 # ---------------------------------------------------------------------------
-# Registries
+# Registries (immutable tuples; registration uses copy-on-write under lock)
 # ---------------------------------------------------------------------------
 
-_sync_factories: list[SyncAdapterFactory] = [
+_registry_lock = threading.Lock()
+
+_sync_factories: tuple[SyncAdapterFactory, ...] = (
     _try_requests,
     _try_niquests,
     _try_httpx,
     _try_urllib3,
-]
+)
 
-_async_factories: list[AsyncAdapterFactory] = [
+_async_factories: tuple[AsyncAdapterFactory, ...] = (
     _try_async_niquests,
     _try_async_httpx,
     _try_async_aiohttp,
-]
+)
 
 
 def register_sync_adapter(factory: SyncAdapterFactory) -> None:
@@ -138,7 +141,9 @@ def register_sync_adapter(factory: SyncAdapterFactory) -> None:
     Factories are tried in registration order; the first non-``None``
     result wins.
     """
-    _sync_factories.append(factory)
+    global _sync_factories  # noqa: PLW0603
+    with _registry_lock:
+        _sync_factories = (*_sync_factories, factory)
 
 
 def register_async_adapter(factory: AsyncAdapterFactory) -> None:
@@ -147,7 +152,9 @@ def register_async_adapter(factory: AsyncAdapterFactory) -> None:
     *factory* is called with a raw client object and must return an
     :class:`~pyhaul.transport.protocols.AsyncTransportSession` or ``None``.
     """
-    _async_factories.append(factory)
+    global _async_factories  # noqa: PLW0603
+    with _registry_lock:
+        _async_factories = (*_async_factories, factory)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_dispatch.py
+++ b/tests/test_session_dispatch.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import pytest
 
+import pyhaul._session_dispatch as session_dispatch
 from pyhaul._session_dispatch import (
-    _async_factories,
-    _sync_factories,
     coerce_async_session,
     coerce_sync_session,
     register_async_adapter,
@@ -108,15 +107,15 @@ class TestRegisterSyncAdapter:
             calls.append(obj)
             return None
 
-        original_len = len(_sync_factories)
+        saved = session_dispatch._sync_factories
         register_sync_adapter(fake_factory)
         try:
             with pytest.raises(TypeError):
                 coerce_sync_session(sentinel)
             assert sentinel in calls
         finally:
-            _sync_factories.pop()
-            assert len(_sync_factories) == original_len
+            session_dispatch._sync_factories = saved
+            assert len(session_dispatch._sync_factories) == len(saved)
 
     def test_custom_factory_wins(self) -> None:
         niquests = pytest.importorskip("niquests")
@@ -127,12 +126,13 @@ class TestRegisterSyncAdapter:
         def always_match(obj: object) -> TransportSession | None:
             return custom_adapter
 
+        saved = session_dispatch._sync_factories
         register_sync_adapter(always_match)
         try:
             result = coerce_sync_session(object())
             assert result is custom_adapter
         finally:
-            _sync_factories.pop()
+            session_dispatch._sync_factories = saved
 
 
 class TestRegisterAsyncAdapter:
@@ -143,12 +143,12 @@ class TestRegisterAsyncAdapter:
             calls.append(obj)
             return None
 
-        original_len = len(_async_factories)
+        saved = session_dispatch._async_factories
         register_async_adapter(fake_factory)
         try:
             with pytest.raises(TypeError):
                 coerce_async_session(object())
             assert len(calls) == 1
         finally:
-            _async_factories.pop()
-            assert len(_async_factories) == original_len
+            session_dispatch._async_factories = saved
+            assert len(session_dispatch._async_factories) == len(saved)


### PR DESCRIPTION
Fixes #38.

Registration uses a lock plus copy-on-write tuples; `coerce_*` iterates an immutable snapshot without locking.