### PR TITLE
chore: cleanup hardening rollup (async executor, redirects, Content-Length, docs)

### DIFF
--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -31,6 +31,26 @@ The engine handles each case without caller intervention.
 - **Discard.** Delete both `.part` and `.part.ctrl` to force a
   restart.
 
+### Stream completeness
+
+After the response body finishes, ``after_stream()``
+compares bytes written to **`plan.extent`** when that value is known from
+**`Content-Range`** (full representation length on **206**). If the stream ends
+with **`plan.cursor < plan.extent`**, pyhaul raises [`PartialHaulError`][pyhaul._types.PartialHaulError]
+and saves checkpoint — this covers “server promised *N* bytes for this
+response, delivered fewer.”
+
+Supported HTTP clients obey transfer framing, so pyhaul does **not** add a
+separate “bytes received vs `Content-Length`” gate for overflow: the raw-byte
+iterator stops at the framing boundary.
+
+When **`Content-Range`** uses an unknown instance length (**`bytes start-end/\*`**),
+**`plan.extent`** may be **`None`**. In that case there is no declared total to
+compare against, so an early-terminated chunked body cannot be detected as
+incomplete here — only as success. That combination is uncommon (e.g. some
+large object stores); fixing it in general would require extra requests (such as
+**`HEAD`**) that pyhaul deliberately avoids.
+
 ## Sidecar file naming and preflight
 
 All sidecar files are derived from the caller-provided destination path by

--- a/docs/guides/adapters.md
+++ b/docs/guides/adapters.md
@@ -47,6 +47,17 @@ their own). To adjust headers inside the adapter layer — for example tests or
 telemetry — implement or wrap [`prepare_headers()`][pyhaul.transport.protocols.TransportSession.prepare_headers];
 see [Writing a Custom Adapter](custom-transport.md).
 
+### Redirects
+
+pyhaul does not override your HTTP client's redirect policy. Library defaults differ:
+**`httpx.Client`** / **`httpx.AsyncClient`** use **`follow_redirects=False`**
+(httpx treats opt-in redirect following as conservative with respect to credentials on
+cross-host redirects); **`requests.Session`**, **`niquests.Session`**,
+**`aiohttp.ClientSession`**, and urllib3 (via pyhaul's adapter) follow redirects in the
+usual configurations unless you turn that off. CDN and mirror URLs often redirect — configure
+the session or client you pass to pyhaul accordingly (for example
+`httpx.Client(follow_redirects=True)`).
+
 ## Per-client examples
 
 ### httpx (sync)
@@ -232,8 +243,10 @@ client = httpx.Client(
 - Both sync (`httpx.Client`) and async (`httpx.AsyncClient`) are supported.
 - pyhaul uses `response.iter_raw()` / `response.aiter_raw()` to bypass
   content decoding, ensuring byte-accurate resume.
-- `follow_redirects` from `TransportRequestOptions` maps to httpx's
-  `follow_redirects` parameter.
+- Per-request **`follow_redirects`** can be forwarded via **`TransportRequestOptions`**
+  when an adapter receives it (see [Writing a Custom Adapter](custom-transport.md)); otherwise
+  httpx uses your client's default (constructor default is `follow_redirects=False` — see
+  [Redirects](#redirects) above).
 
 ### requests
 

--- a/src/pyhaul/_engine_common.py
+++ b/src/pyhaul/_engine_common.py
@@ -52,6 +52,9 @@ _HTTP_200 = 200
 _HTTP_206 = 206
 _HTTP_416 = 416
 
+# Final responses when the underlying client chose not to follow (library default or explicit).
+_REDIRECT_STATUSES: frozenset[int] = frozenset({301, 302, 303, 307, 308})
+
 
 # ─── Dataclasses ──────────────────────────────────────────────────
 
@@ -189,7 +192,21 @@ def handle_response(
         return _plan_206(headers, prep, state, resp_etag=resp_etag, content_type=resp_ct)
 
     if status == _HTTP_200:
-        return _plan_200(headers, state, resp_etag=resp_etag, content_type=resp_ct)
+        return _plan_200(headers, prep, state, resp_etag=resp_etag, content_type=resp_ct)
+
+    if status in _REDIRECT_STATUSES:
+        loc = (headers.get("Location") or "").strip()
+        if loc:
+            reason = (
+                f"The server responded with HTTP {status} and redirected to {loc!r}, "
+                "but redirects were not followed, so the download never reached the final resource."
+            )
+        else:
+            reason = (
+                f"The server responded with HTTP {status} with a redirect to another URL, "
+                "but redirects were not followed, so the download never reached the final resource."
+            )
+        raise UnexpectedStatusError(status, headers, reason=reason)
 
     raise UnexpectedStatusError(status, headers)
 
@@ -318,15 +335,48 @@ def _plan_206(
     )
 
 
+def _parse_content_length(raw: str | None) -> int | None:
+    """Parse ``Content-Length`` for full-response (200) planning.
+
+    Values are normally stripped by :class:`~pyhaul.transport.types.TransportHeaders`;
+    we still strip here for defense in depth.
+
+    Some misbehaving proxies emit comma-separated duplicate lengths (see RFC 7230).
+    """
+    if raw is None:
+        return None
+    s = raw.strip()
+    tokens = [t.strip() for t in s.split(",") if t.strip()]
+    if not tokens or any(not t.isdigit() for t in tokens):
+        return None
+    if len(set(tokens)) > 1:
+        return None
+    return int(tokens[0])
+
+
 def _plan_200(
     headers: TransportHeaders,
+    prep: PrepareHaul,
     state: HaulState,
     *,
     resp_etag: ETag,
     content_type: str,
 ) -> StreamPlan:
-    cl_str = headers.get("Content-Length")
-    resp_cl = int(cl_str) if cl_str and cl_str.isdigit() else None
+    resp_cl = _parse_content_length(headers.get("Content-Length"))
+
+    if resp_cl == 0 and prep.cursor > 0:
+        logger.info(
+            "200 OK with Content-Length 0 while resuming had partial progress "
+            "(cursor=%s, request_byte=%s); treating as empty full representation "
+            "and discarding prior bytes — often CDN/misconfiguration vs Range",
+            prep.cursor,
+            prep.request_byte,
+            extra={
+                "pyhaul_resume_cursor": prep.cursor,
+                "pyhaul_request_byte": prep.request_byte,
+                "pyhaul_content_length": resp_cl,
+            },
+        )
 
     state.valid_length = 0
     state.hashes = []
@@ -398,7 +448,12 @@ def write_chunk(
 
 
 def after_stream(plan: StreamPlan, prep: PrepareHaul, state: HaulState) -> CompleteHaul:
-    """Post-loop: check completeness, trim junk tail, finalize or raise partial."""
+    """Post-loop: compare ``cursor`` to ``extent`` when known, trim junk tail, finalize.
+
+    When ``plan.extent`` is ``None`` (e.g. **206** with ``Content-Range`` whose
+    total length is ``*``), there is no byte budget for ``cursor`` to satisfy,
+    so a truncated chunked body cannot be detected as incomplete here.
+    """
     if plan.extent is not None and plan.cursor < plan.extent:
         save_checkpoint(prep.ctrl_path, plan, prep)
         raise PartialHaulError("stream ended before extent reached")

--- a/src/pyhaul/async_engine.py
+++ b/src/pyhaul/async_engine.py
@@ -25,7 +25,6 @@ from pyhaul._engine_common import (
     StreamPlan,
     after_stream,
     datasync,
-    flush_dirty,
     handle_response,
     open_part_file,
     prepare_haul,
@@ -45,7 +44,43 @@ def _sync_flush(fd: int, plan: StreamPlan, prep: PrepareHaul) -> None:
     save_checkpoint(prep.ctrl_path, plan, prep)
 
 
-async def haul_async(
+def _datasync_and_close(fd: int) -> None:
+    """Final fdatasync then close fd, atomically inside the executor.
+
+    Bundling the datasync and close into a single executor function
+    eliminates the cancellation race where the event-loop thread closes
+    *fd* while an in-flight ``datasync(fd)`` is still running in a worker
+    thread (which surfaces as ``OSError: [Errno 9] Bad file descriptor``).
+    Both syscalls now run serially on the same thread.
+    """
+    try:
+        datasync(fd)
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+
+
+def _flush_dirty_and_close(fd: int, plan: StreamPlan, prep: PrepareHaul) -> None:
+    """Best-effort dirty flush + checkpoint, then close fd.
+
+    Used on the ``TransportError`` path.  Same atomicity story as
+    :func:`_datasync_and_close`: every operation that touches *fd* runs
+    on the executor thread, so no event-loop-side close can race with
+    this work.
+    """
+    try:
+        if plan.bytes_since_flush > 0:
+            with contextlib.suppress(OSError):
+                datasync(fd)
+            with contextlib.suppress(OSError):
+                save_checkpoint(prep.ctrl_path, plan, prep)
+            plan.bytes_since_flush = 0
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+
+
+async def haul_async(  # noqa: C901 — stream loop + transport/error paths; keep linear
     url: str,
     client: AsyncTransportSession | object,
     *,
@@ -102,6 +137,13 @@ async def haul_async(
                 extra={"pyhaul_part_path": str(prep.part_path)},
             )
             fd = open_part_file(plan, prep.part_path)
+            # Once True, the executor finalizer owns *fd* and is solely
+            # responsible for closing it.  The event-loop-side fallback
+            # close in the outer ``finally`` then becomes a no-op.  This
+            # prevents a cancellation race where the loop thread closes
+            # *fd* while a queued executor task is still calling
+            # ``datasync(fd)`` on it (EBADF).
+            fd_finalized_by_executor = False
             try:
                 async for chunk in resp.aiter_raw_bytes(chunk_size=chunk_size):
                     os.write(fd, chunk)
@@ -120,14 +162,32 @@ async def haul_async(
                     if on_progress is not None:
                         on_progress(state)
 
-                await loop.run_in_executor(None, datasync, fd)
+                # Hand *fd* over to the executor for the final datasync +
+                # close.  The flag is set BEFORE the await so a
+                # cancellation here does not race the executor: the
+                # worker thread runs to completion and closes *fd*
+                # serially after datasync, with no concurrent close
+                # from the loop thread.
+                fd_finalized_by_executor = True
+                await loop.run_in_executor(None, _datasync_and_close, fd)
             except TransportError as exc:
-                flush_dirty(fd, plan, prep)
-                os.close(fd)
+                fd_finalized_by_executor = True
+                await loop.run_in_executor(
+                    None,
+                    _flush_dirty_and_close,
+                    fd,
+                    plan,
+                    prep,
+                )
                 raise PartialHaulError("connection lost during stream") from exc
             finally:
-                with contextlib.suppress(OSError):
-                    os.close(fd)
+                if not fd_finalized_by_executor:
+                    # Reachable only if a synchronous error occurred
+                    # between opening *fd* and any executor handoff.
+                    # Safe to close on the loop thread because no
+                    # executor task is in flight against this fd.
+                    with contextlib.suppress(OSError):
+                        os.close(fd)
 
             return after_stream(plan, prep, state)
     except TransportConnectionError as ce:

--- a/tests/redirect_support.py
+++ b/tests/redirect_support.py
@@ -1,0 +1,235 @@
+"""Shared helpers for live redirect integration tests.
+
+``haul()`` / ``haul_async()`` do not yet thread :class:`~pyhaul.transport.types.TransportRequestOptions`
+from callers, so adapters usually rely on each HTTP client's defaults. Tests pin
+``allow_redirects`` by wrapping a concrete adapter and merging
+:class:`~pyhaul.transport.types.TransportRequestOptions` on every ``stream_get``, giving every
+backend an explicit redirect-on vs redirect-off path without changing production APIs.
+"""
+
+from __future__ import annotations
+
+import gc
+import http.server as http_server
+import threading
+import time
+from collections.abc import AsyncIterator, Iterator, Mapping
+from contextlib import AbstractAsyncContextManager, asynccontextmanager, contextmanager
+from typing import cast
+from urllib.parse import urlparse
+
+from pyhaul._types import Url
+from pyhaul.transport.protocols import (
+    AsyncTransportResponse,
+    AsyncTransportSession,
+    TransportResponse,
+    TransportSession,
+)
+from pyhaul.transport.types import TransportHeaders, TransportRequestOptions
+from tests.live_backends import make_native, make_transport
+
+CONTENT = b"redirect-matrix-download-body"
+ETAG = '"matrix-redirect"'
+
+LIVE_ASYNC_BACKENDS: tuple[str, ...] = ("httpx", "aiohttp", "niquests")
+
+
+def _parse_range(header: str, content_len: int) -> tuple[int, int] | None:
+    if not header:
+        return None
+    try:
+        start_s, end_s = header.replace("bytes=", "").split("-")
+        start = int(start_s)
+        end = int(end_s) if end_s else content_len - 1
+    except (ValueError, IndexError):
+        return None
+    return start, end
+
+
+class _RedirectFollowHandler(http_server.BaseHTTPRequestHandler):
+    """``GET /redirect`` → 302 to ``/final``; ``GET /final`` serves :data:`CONTENT` with Range."""
+
+    def do_GET(self) -> None:
+        path = urlparse(self.path).path.rstrip("/") or "/"
+        host, port = cast("tuple[str, int]", self.server.server_address)
+        base = f"http://{host}:{port}"
+
+        if path == "/redirect":
+            self.send_response(302)
+            self.send_header("Location", f"{base}/final")
+            self.end_headers()
+            return
+
+        if path != "/final":
+            self.send_error(404)
+            return
+
+        range_hdr = self.headers.get("Range", "")
+        parsed = _parse_range(range_hdr, len(CONTENT))
+        if parsed is None:
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(CONTENT)))
+            self.send_header("ETag", ETAG)
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+            self.wfile.write(CONTENT)
+            return
+
+        start, end = parsed
+        if start >= len(CONTENT):
+            self.send_response(416)
+            self.send_header("Content-Range", f"bytes */{len(CONTENT)}")
+            self.send_header("ETag", ETAG)
+            self.end_headers()
+            return
+
+        end = min(end, len(CONTENT) - 1)
+        chunk = CONTENT[start : end + 1]
+        self.send_response(206)
+        self.send_header("Content-Range", f"bytes {start}-{end}/{len(CONTENT)}")
+        self.send_header("Content-Length", str(len(chunk)))
+        self.send_header("ETag", ETAG)
+        self.end_headers()
+        self.wfile.write(chunk)
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        pass
+
+
+class _ThreadingHTTPServer(http_server.ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+@contextmanager
+def redirect_server_context() -> Iterator[tuple[Url, bytes]]:
+    """Serve ``GET /redirect`` → 302 ``/final`` until context exits."""
+    srv = _ThreadingHTTPServer(("127.0.0.1", 0), _RedirectFollowHandler)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    try:
+        port = srv.server_address[1]
+        yield Url(f"http://127.0.0.1:{port}/redirect"), CONTENT
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        thread.join(timeout=2.0)
+        time.sleep(0.01)
+        gc.collect()
+
+
+def merge_allow_redirects(options: TransportRequestOptions | None, *, pin: bool) -> TransportRequestOptions:
+    """Force ``allow_redirects`` while preserving any other fields from *options* (tests only)."""
+    if options is None:
+        return TransportRequestOptions(allow_redirects=pin)
+    return TransportRequestOptions(
+        timeout=options.timeout,
+        verify=options.verify,
+        allow_redirects=pin,
+    )
+
+
+class PinnedRedirectSyncTransport:
+    """Wraps a sync adapter and merges ``TransportRequestOptions(allow_redirects=...)``."""
+
+    __slots__ = ("_allow_redirects", "_inner")
+
+    def __init__(self, inner: TransportSession, *, allow_redirects: bool) -> None:
+        self._inner = inner
+        self._allow_redirects = allow_redirects
+
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        """Forward to the wrapped adapter."""
+        return self._inner.prepare_headers(headers)
+
+    @contextmanager
+    def stream_get(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> Iterator[TransportResponse]:
+        """Pin redirect policy, then open a streaming GET."""
+        merged = merge_allow_redirects(options, pin=self._allow_redirects)
+        with self._inner.stream_get(url, headers=headers, options=merged) as resp:
+            yield resp
+
+
+class PinnedRedirectAsyncTransport:
+    """Wraps an async adapter and merges ``TransportRequestOptions(allow_redirects=...)``."""
+
+    __slots__ = ("_allow_redirects", "_inner")
+
+    def __init__(self, inner: AsyncTransportSession, *, allow_redirects: bool) -> None:
+        self._inner = inner
+        self._allow_redirects = allow_redirects
+
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        """Forward to the wrapped adapter."""
+        return self._inner.prepare_headers(headers)
+
+    def stream_get(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AbstractAsyncContextManager[AsyncTransportResponse]:
+        """Pin redirect policy, then open a streaming GET."""
+        merged = merge_allow_redirects(options, pin=self._allow_redirects)
+
+        @asynccontextmanager
+        async def _cm() -> AsyncIterator[AsyncTransportResponse]:
+            async with self._inner.stream_get(url, headers=headers, options=merged) as resp:
+                yield resp
+
+        return _cm()
+
+
+def build_sync_pinned_transport(backend: str, *, allow_redirects: bool) -> tuple[object, PinnedRedirectSyncTransport]:
+    """Vanilla native client + adapter wrapped so redirect policy is explicit."""
+    native = make_native(backend)
+    inner = make_transport(backend, native)
+    return native, PinnedRedirectSyncTransport(inner, allow_redirects=allow_redirects)
+
+
+def make_async_inner_transport(backend: str, native: object) -> AsyncTransportSession:
+    """Mirror :func:`tests.live_backends.make_transport` for async sessions."""
+    if backend == "httpx":
+        from pyhaul.transport.httpx_adapter import AsyncHttpxAdapter
+
+        return AsyncHttpxAdapter(native)  # type: ignore[arg-type]
+    if backend == "aiohttp":
+        from pyhaul.transport.aiohttp_adapter import AsyncAiohttpAdapter
+
+        return AsyncAiohttpAdapter(native)  # type: ignore[arg-type]
+    if backend == "niquests":
+        from pyhaul.transport.niquests_adapter import AsyncNiquestsAdapter
+
+        return AsyncNiquestsAdapter(native)  # type: ignore[arg-type]
+    msg = f"unknown async backend {backend!r}"
+    raise ValueError(msg)
+
+
+@asynccontextmanager
+async def async_native_session(backend: str) -> AsyncIterator[object]:
+    """Yield an async HTTP client for *backend* (caller must ``importorskip`` first)."""
+    if backend == "httpx":
+        import httpx
+
+        async with httpx.AsyncClient() as client:
+            yield client
+    elif backend == "aiohttp":
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            yield session
+    elif backend == "niquests":
+        import niquests
+
+        async with niquests.AsyncSession() as session:
+            yield session
+    else:
+        msg = f"unknown async backend {backend!r}"
+        raise ValueError(msg)

--- a/tests/test_async_engine.py
+++ b/tests/test_async_engine.py
@@ -398,8 +398,7 @@ class TestAsyncExecutorOffload:
         from collections.abc import Callable
         from typing import Any
 
-        from pyhaul._engine_common import datasync
-        from pyhaul.async_engine import _sync_flush, haul_async
+        from pyhaul.async_engine import _datasync_and_close, _sync_flush, haul_async
 
         body = b"A" * 200
         session = AsyncMockSession()
@@ -427,7 +426,7 @@ class TestAsyncExecutorOffload:
         assert dest.read_bytes() == body
         assert len(offloaded_fns) >= 2, f"expected >=2 executor calls, got {len(offloaded_fns)}"
         assert _sync_flush in offloaded_fns, "periodic flush should be offloaded"
-        assert datasync in offloaded_fns, "final datasync should be offloaded"
+        assert _datasync_and_close in offloaded_fns, "final fdatasync+close should be offloaded"
 
     @pytest.mark.anyio
     async def test_correctness_with_aggressive_flushing(self, tmp_path: Path) -> None:

--- a/tests/test_handle_response_redirect.py
+++ b/tests/test_handle_response_redirect.py
@@ -1,0 +1,57 @@
+"""Tests for redirect-specific messaging in :func:`pyhaul._engine_common.handle_response`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pyhaul._engine_common import PrepareHaul, handle_response
+from pyhaul._types import ETag, HaulState, UnexpectedStatusError, Url
+from pyhaul.transport._headers import TransportHeaders
+
+
+def _minimal_prep() -> PrepareHaul:
+    return PrepareHaul(
+        dest_path=Path("/tmp/pyhaul-test.bin"),
+        parsed_url=Url("http://example.com/file.bin"),
+        part_path=Path("/tmp/pyhaul-test.bin.part"),
+        ctrl_path=Path("/tmp/pyhaul-test.bin.part.ctrl"),
+        start=0,
+        cursor=0,
+        stored_etag=ETag(""),
+        hashes=[],
+        tail_hash=None,
+        block_size=8 * 1024 * 1024,
+        request_byte=0,
+        merged_headers=TransportHeaders.from_pairs([]),
+        t0=0.0,
+    )
+
+
+@pytest.mark.parametrize("status", [301, 302, 303, 307, 308])
+def test_redirect_not_followed_includes_location_and_plain_message(status: int) -> None:
+    headers = TransportHeaders.from_pairs([("Location", "https://cdn.example/other.bin"), ("Server", "test")])
+    with pytest.raises(UnexpectedStatusError) as ctx:
+        handle_response(status, headers, _minimal_prep(), HaulState())
+    exc = ctx.value
+    assert exc.status_code == status
+    assert "were not followed" in exc.reason
+    assert "https://cdn.example/other.bin" in exc.reason
+    assert "redirect" in exc.reason.lower()
+
+
+def test_redirect_without_location_message() -> None:
+    headers = TransportHeaders.from_pairs([])
+    with pytest.raises(UnexpectedStatusError) as ctx:
+        handle_response(302, headers, _minimal_prep(), HaulState())
+    assert ctx.value.status_code == 302
+    assert "were not followed" in ctx.value.reason
+    assert "another URL" in ctx.value.reason
+
+
+def test_non_redirect_unexpected_status_generic_reason() -> None:
+    headers = TransportHeaders.from_pairs([])
+    with pytest.raises(UnexpectedStatusError) as ctx:
+        handle_response(418, headers, _minimal_prep(), HaulState())
+    assert ctx.value.reason == "unexpected HTTP 418"

--- a/tests/test_live_async.py
+++ b/tests/test_live_async.py
@@ -11,6 +11,7 @@ import asyncio
 import contextlib
 import gc
 import http.server as _http_server
+import os
 import socket
 import threading
 import time
@@ -95,6 +96,11 @@ class _ServerFaults:
         attempt = self.hit(file_idx)
         return attempt < self.truncate_first_n
 
+    def reset_attempts(self) -> None:
+        """Clear per-file counters (for stress loops that reuse one server)."""
+        with self._lock:
+            self._hits.clear()
+
 
 class _MultiFileHandler(_http_server.BaseHTTPRequestHandler):
     """Serves /0, /1, /2, … each with deterministic content seeded by index."""
@@ -123,12 +129,14 @@ class _MultiFileHandler(_http_server.BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Length", str(len(content)))
         self.send_header("ETag", f'"seed-{len(content)}"')
+        if truncate:
+            # Announce close before framing the body as keep-alive; avoids slam-close EBADF races.
+            self.send_header("Connection", "close")
+            self.close_connection = True
         self.end_headers()
         if truncate:
             self.wfile.write(content[: len(content) // 2])
             self.wfile.flush()
-            self.connection.close()
-            self.close_connection = True
         else:
             self.wfile.write(content)
 
@@ -148,12 +156,13 @@ class _MultiFileHandler(_http_server.BaseHTTPRequestHandler):
         self.send_header("Content-Range", f"bytes {start}-{end}/{len(content)}")
         self.send_header("Content-Length", str(len(chunk)))
         self.send_header("ETag", f'"seed-{len(content)}"')
+        if truncate:
+            self.send_header("Connection", "close")
+            self.close_connection = True
         self.end_headers()
         if truncate:
             self.wfile.write(chunk[: len(chunk) // 2])
             self.wfile.flush()
-            self.connection.close()
-            self.close_connection = True
         else:
             self.wfile.write(chunk)
 
@@ -394,3 +403,77 @@ class TestConcurrentAsyncDownloads:
             expected = _deterministic(file_size, seed=i)
             assert (dest_dir / f"file_{i}.bin").read_bytes() == expected
             assert partial_count[i] >= 1, f"file {i}: expected at least 1 PartialHaulError"
+
+
+class TestTruncationConcurrentStress:
+    """Tight-loop regression harness for async-engine teardown races.
+
+    Mirrors :meth:`TestConcurrentAsyncDownloads.test_truncation_and_resume_concurrent`
+    (``TaskGroup``, shared client, first GET truncated per file, resume loop). Running
+    many iterations increases the chance of surfacing an executor cancellation race on
+    the final ``fdatasync`` / ``close`` path (e.g. ``EBADF`` in a worker thread while
+    the event loop closes the fd).
+
+    **Opt-in:** set ``PYHAUL_TRUNCATION_STRESS_ROUNDS`` to a positive integer (e.g.
+    ``200``). If unset or ``0``, the test is skipped so default CI stays fast.
+
+    Example::
+
+        PYHAUL_TRUNCATION_STRESS_ROUNDS=200 \\
+          uv run pytest tests/test_live_async.py::TestTruncationConcurrentStress \\
+          -q --tb=short
+    """
+
+    @pytest.mark.anyio
+    async def test_truncation_and_resume_concurrent_stress_loop(
+        self,
+        multi_file_server: tuple[str, Path, int, int, _ServerFaults],
+    ) -> None:
+        pytest.importorskip("httpx")
+        rounds_s = os.environ.get("PYHAUL_TRUNCATION_STRESS_ROUNDS", "").strip()
+        if not rounds_s or not rounds_s.isdigit():
+            pytest.skip(
+                "Set PYHAUL_TRUNCATION_STRESS_ROUNDS to a positive integer "
+                "(e.g. 200) to run truncation TaskGroup stress loop",
+            )
+        rounds = int(rounds_s)
+        if rounds < 1:
+            pytest.skip(
+                "PYHAUL_TRUNCATION_STRESS_ROUNDS must be >= 1 (omit or set 0 to skip this stress test)",
+            )
+
+        base_url, dest_dir, _file_count, file_size, faults = multi_file_server
+        target_count = 4
+
+        async with _make_async_client("httpx") as client:
+            for round_ix in range(rounds):
+                faults.truncate_first_n = 1
+                faults.reset_attempts()
+
+                results: dict[int, CompleteHaul] = {}
+                async with asyncio.TaskGroup() as tg:
+                    for i in range(target_count):
+
+                        async def _download(
+                            idx: int = i,
+                            *,
+                            r: int = round_ix,
+                            bucket: dict[int, CompleteHaul] = results,
+                        ) -> None:
+                            url = f"{base_url}/{idx}"
+                            dest = dest_dir / f"stress_r{r}_f{idx}.bin"
+                            for attempt in range(5):
+                                try:
+                                    bucket[idx] = await haul_async(url, client, dest=str(dest))
+                                    break
+                                except PartialHaulError:
+                                    assert attempt < 4, f"round {r} file {idx}: still partial after 5 attempts"
+
+                        tg.create_task(_download())
+
+                assert len(results) == target_count
+                for i in range(target_count):
+                    expected = _deterministic(file_size, seed=i)
+                    path = dest_dir / f"stress_r{round_ix}_f{i}.bin"
+                    assert path.read_bytes() == expected
+                    assert results[i].sha256 == _tree_hash(expected)

--- a/tests/test_parse_content_length.py
+++ b/tests/test_parse_content_length.py
@@ -1,0 +1,42 @@
+"""Unit tests for :func:`pyhaul._engine_common._parse_content_length`."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyhaul._engine_common import _parse_content_length
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, None),
+        ("", None),
+        (" ", None),
+        ("42", 42),
+        ("  99  ", 99),
+        ("1234, 1234", 1234),
+        ("1234,1234", 1234),
+        ("1000, 1000, 1000", 1000),
+    ],
+)
+def test_parse_content_length_ok(raw: str | None, expected: int | None) -> None:
+    assert _parse_content_length(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "abc",
+        "12a",
+        "12 34",
+        "+12",
+        "-5",
+        "1.5",
+        "1, 2",
+        "10, 11",
+        "10,,11",
+    ],
+)
+def test_parse_content_length_invalid(raw: str) -> None:
+    assert _parse_content_length(raw) is None

--- a/tests/test_redirect_live_matrix.py
+++ b/tests/test_redirect_live_matrix.py
@@ -1,0 +1,89 @@
+"""Live redirect matrix: every supported backend by redirect on/off.
+
+Redirect policy is pinned via :class:`~tests.redirect_support.PinnedRedirectSyncTransport`
+/ :class:`~tests.redirect_support.PinnedRedirectAsyncTransport` so tests exercise explicit
+``TransportRequestOptions.allow_redirects`` for each adapter (see :mod:`tests.redirect_support`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from pyhaul._types import CompleteHaul, UnexpectedStatusError, Url
+from pyhaul.async_engine import haul_async
+from pyhaul.engine import haul
+from tests.live_backends import LIVE_BACKENDS, close_native
+from tests.redirect_support import (
+    LIVE_ASYNC_BACKENDS,
+    PinnedRedirectAsyncTransport,
+    async_native_session,
+    build_sync_pinned_transport,
+    make_async_inner_transport,
+    redirect_server_context,
+)
+
+
+@pytest.fixture
+def redirect_server_url() -> Generator[tuple[Url, bytes], None, None]:
+    with redirect_server_context() as pair:
+        yield pair
+
+
+@pytest.mark.parametrize("allow_redirects", [True, False])
+@pytest.mark.parametrize("backend", LIVE_BACKENDS)
+def test_sync_redirect_follow_setting(
+    tmp_path: Path,
+    redirect_server_url: tuple[Url, bytes],
+    backend: str,
+    allow_redirects: bool,
+) -> None:
+    pytest.importorskip(backend)
+    url, expected_body = redirect_server_url
+    dest = tmp_path / f"sync_{backend}_{allow_redirects}.bin"
+
+    native, transport = build_sync_pinned_transport(backend, allow_redirects=allow_redirects)
+    try:
+        if allow_redirects:
+            result = haul(url, transport, dest=str(dest))
+            assert isinstance(result, CompleteHaul)
+            assert dest.read_bytes() == expected_body
+        else:
+            with pytest.raises(UnexpectedStatusError) as ctx:
+                haul(url, transport, dest=str(dest))
+            assert ctx.value.status_code == 302
+            assert "were not followed" in ctx.value.reason
+            assert "redirect" in ctx.value.reason.lower()
+    finally:
+        close_native(native)
+
+
+@pytest.mark.parametrize("allow_redirects", [True, False])
+@pytest.mark.parametrize("backend", LIVE_ASYNC_BACKENDS)
+@pytest.mark.anyio
+async def test_async_redirect_follow_setting(
+    tmp_path: Path,
+    redirect_server_url: tuple[Url, bytes],
+    backend: str,
+    allow_redirects: bool,
+) -> None:
+    pytest.importorskip(backend)
+    url, expected_body = redirect_server_url
+    dest = tmp_path / f"async_{backend}_{allow_redirects}.bin"
+
+    async with async_native_session(backend) as native:
+        inner = make_async_inner_transport(backend, native)
+        transport = PinnedRedirectAsyncTransport(inner, allow_redirects=allow_redirects)
+
+        if allow_redirects:
+            result = await haul_async(url, transport, dest=str(dest))
+            assert isinstance(result, CompleteHaul)
+            assert dest.read_bytes() == expected_body
+        else:
+            with pytest.raises(UnexpectedStatusError) as ctx:
+                await haul_async(url, transport, dest=str(dest))
+            assert ctx.value.status_code == 302
+            assert "were not followed" in ctx.value.reason
+            assert "redirect" in ctx.value.reason.lower()


### PR DESCRIPTION
Squashed rollup from chore/cleanup-hardening: async engine executor fdatasync+close teardown, redirect/matrix tests, Content-Length parsing, design/adapters docs, truncation stress harness opt-in.