### PR TITLE
feat(probe): probe API, stream_head transport, and download stack updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,13 @@ your call — a for-loop, `tenacity`, or nothing. Concurrency limiting
 file per call and doesn't manage parallelism.
 
 ```python
-def haul(url, client, *, dest, state=None) -> CompleteHaul: ...
-async def haul_async(url, client, *, dest, state=None) -> CompleteHaul: ...
+def haul(url, client, *, dest) -> CompleteHaul: ...
+async def haul_async(url, client, *, dest) -> CompleteHaul: ...
 ```
 
-`state` is an optional `HaulState` bag, updated in-place as bytes
-land on disk — works identically in sync and async. See
+Optional `HaulState` (progress bag, updated in-place) and other keyword-only
+options (extra headers, progress hooks, buffer sizing) are documented on the
+site. See
 [docs/DESIGN.md](docs/DESIGN.md) for the exception hierarchy, transport
 adapters, and download lifecycle.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -7,7 +7,7 @@
 | Exception | When | Retryable? |
 | --- | --- | --- |
 | `PartialHaulError` | Stream ended before all bytes arrived. | Yes — call `haul()` again |
-| `UnexpectedStatusError` | Server returned a non-download status (429, 503, 404, …). | Lets caller decide — check `exc.is_transient` |
+| `UnexpectedStatusError` | Server returned a non-download status (408, 429, 5xx, 404, …). | Lets caller decide — check `exc.is_transient` / `exc.is_server_error` |
 | `ServerMisconfiguredError` | Server violated HTTP in a way that prevents safe resume. | No |
 | `ContentRangeError` | 206 Content-Range doesn't match the requested range. | Often yes |
 | `ControlFileError` | `.part.ctrl` is corrupt or version-mismatched. Discarded on next attempt. | Auto-recovers |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -48,8 +48,9 @@ testing, etc.), implement the `TransportSession` protocol: a single
 
 1. `haul()` reads `.part.ctrl` (if it exists) to recover the cursor
    position and stored ETag.
-2. Sends `Range: bytes=<cursor>-` with `If-Range: <etag>` (omitted
-   when no ETag is stored).
+2. Sends `Range: bytes=<cursor>-` with `If-Range: <etag>` when a **strong**
+   ETag is stored — omitted when there is no ETag **or** when only a **weak**
+   ETag is available (weak validators are not used for byte-range preconditioning).
 3. **206 Partial Content** — server honors the range. Stream appends
    from the cursor.
 4. **200 OK** — server ignores the range (resource changed, or server

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -82,12 +82,13 @@ your call — a for-loop, `tenacity`, or nothing. Concurrency limiting
 file per call and doesn't manage parallelism.
 
 ```python
-def haul(url, client, *, dest, state=None) -> CompleteHaul: ...
-async def haul_async(url, client, *, dest, state=None) -> CompleteHaul: ...
+def haul(url, client, *, dest) -> CompleteHaul: ...
+async def haul_async(url, client, *, dest) -> CompleteHaul: ...
 ```
 
-`state` is an optional `HaulState` bag, updated in-place as bytes
-land on disk — works identically in sync and async. See
+Optional `HaulState` (progress bag, updated in-place) and other keyword-only
+options (extra headers, progress hooks, buffer sizing) are documented on the
+site. See
 [docs/DESIGN.md](https://github.com/chad-loder/pyhaul/blob/main/docs/DESIGN.md) for the exception hierarchy, transport
 adapters, and download lifecycle.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -100,7 +100,11 @@ control file from causing the parser to misinterpret lengths or ETag strings.
 
 Supported Tags:
 
-- `1`: ETag (UTF-8 string)
+- `1`: ETag (UTF-8 string — RFC ``entity-tag`` text: ``"<opaque>"``,
+  ``W/"<opaque>"``, or ``*``, as produced by
+  :meth:`EntityTag.to_canonical <pyhaul.etag.EntityTag.to_canonical>`;
+  legacy bare tokens still load via
+  :meth:`EntityTag.from_canonical <pyhaul.etag.EntityTag.from_canonical>`)
 - `2`: Reported length (64-bit unsigned integer — server-claimed full size)
 - `3`: Tail Hash (32-byte SHA-256 binary digest of the current partial block)
 

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -127,7 +127,7 @@ pyhaul's exception hierarchy separates retryable from non-retryable errors:
 
 - [`PartialHaulError`][pyhaul._types.PartialHaulError] — the stream ended early, but progress is saved. Retry.
 - [`UnexpectedStatusError`][pyhaul._types.UnexpectedStatusError] — server returned a non-download status
-  (429, 503, 404, …). Check `exc.is_transient` to decide whether to retry,
+  (408, 425, 429, many 5xx, CDN-specific codes, 404, …). Check `exc.is_transient` (or `exc.is_server_error` for any HTTP 5xx) to decide whether to retry,
   and inspect `exc.retry_after` for server-requested backoff.
 - [`ServerMisconfiguredError`][pyhaul._types.ServerMisconfiguredError] — the server violated HTTP in a way that makes
   safe resume impossible. Don't retry.

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -128,7 +128,7 @@ pyhaul's exception hierarchy separates retryable from non-retryable errors:
 - [`PartialHaulError`][pyhaul._types.PartialHaulError] — the stream ended early, but progress is saved. Retry.
 - [`UnexpectedStatusError`][pyhaul._types.UnexpectedStatusError] — server returned a non-download status
   (408, 425, 429, many 5xx, CDN-specific codes, 404, …). Check `exc.is_transient` (or `exc.is_server_error` for any HTTP 5xx) to decide whether to retry,
-  and inspect `exc.retry_after` for server-requested backoff.
+  and inspect `exc.retry_after` / `exc.retry_after_seconds` for server-requested backoff.
 - [`ServerMisconfiguredError`][pyhaul._types.ServerMisconfiguredError] — the server violated HTTP in a way that makes
   safe resume impossible. Don't retry.
 - [`ControlFileError`][pyhaul._types.ControlFileError] — the checkpoint file is corrupt. Auto-recovers on next

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -6,13 +6,17 @@
 
 1. `haul()` reads `.part.ctrl` (if it exists) to recover the cursor
    position and stored ETag.
-2. Sends `Range: bytes=<cursor>-` with `If-Range: <etag>` (omitted
-   when no ETag is stored).
+2. Sends `Range: bytes=<cursor>-` with `If-Range: <etag>` when a **strong**
+   ETag is stored — omitted when there is no ETag **or** when only a **weak**
+   ETag is available (weak validators are not used for byte-range preconditioning).
 3. **206 Partial Content** — server honors the range. Stream appends
    from the cursor.
 4. **200 OK** — server ignores the range (resource changed, or server
    doesn't support ranges). Cursor resets to 0; stream overwrites from
    the beginning.
+   Rare mislabeled **206** responses fall here too: if ``Content-Range``
+   describes the entire representation from byte 0 while we asked for a resume,
+   pyhaul treats that like **200** (same cursor reset).
 5. **416 Range Not Satisfiable** — the server's reported total matches
    the cursor (already complete) or the representation shrank (checkpoint
    reset, next call restarts).

--- a/docs/guides/async.md
+++ b/docs/guides/async.md
@@ -382,8 +382,16 @@ to run the sync `haul()` in a thread without blocking the event loop:
 
 ## Progress reporting
 
-The `on_progress` callback is synchronous even in async mode — pass a
-[`HaulState`][pyhaul._types.HaulState] to track progress. Keep the callback fast:
+`haul_async` accepts an [`AsyncProgressCallback`][pyhaul._types.AsyncProgressCallback]:
+either a synchronous callable or one whose return value is awaitable (for example
+`async def`). The engine awaits each chunk's hook before reading the next chunk,
+so you can push updates over websockets or similar without wrapping each call in
+[`asyncio.create_task`][asyncio.create_task]. Keep work bounded — progress runs on the
+download's critical path.
+
+[`haul()`][pyhaul.engine.haul] still accepts only synchronous callbacks.
+
+Pass a [`HaulState`][pyhaul._types.HaulState] to track progress. Example with a sync hook:
 
 ```python
 from pyhaul import haul_async, HaulState

--- a/docs/guides/async.md
+++ b/docs/guides/async.md
@@ -394,10 +394,15 @@ download's critical path.
 Pass a [`HaulState`][pyhaul._types.HaulState] to track progress. Example with a sync hook:
 
 ```python
+import asyncio
+
+import httpx
+
 from pyhaul import haul_async, HaulState
 
 state = HaulState()
 high_water = 0
+
 
 def show_progress(state: HaulState):
     global high_water
@@ -408,12 +413,18 @@ def show_progress(state: HaulState):
         pct = high_water / state.reported_length * 100
         print(f"\r{pct:.1f}%", end="", flush=True)
 
+
 async def main():
+    url = "https://example.com/file.bin"
     async with httpx.AsyncClient() as client:
-        result = await haul_async(
-            url, client, dest="file.bin",
-            state=state, on_progress=show_progress,
+        await haul_async(
+            url,
+            client,
+            dest="file.bin",
+            state=state,
+            on_progress=show_progress,
         )
+
 
 asyncio.run(main())
 ```

--- a/docs/guides/async.md
+++ b/docs/guides/async.md
@@ -409,3 +409,12 @@ async def main():
 
 asyncio.run(main())
 ```
+
+!!! note "Cancellation and outer timeouts"
+    pyhaul only maps **HTTP client** failures (timeouts, disconnects, TLS, etc.)
+    to [`TransportError`][pyhaul.transport.errors.TransportError] subclasses.
+    **Caller-owned** deadlines — `asyncio.wait_for(...)`, `asyncio.Task.cancel()`, or
+    cooperative cancellation — surface as `asyncio.TimeoutError` or
+    `asyncio.CancelledError`. Those bypass adapter translation and are **not**
+    turned into [`PartialHaulError`][pyhaul._types.PartialHaulError]; treat them as
+    application policy, not transport failure.

--- a/docs/guides/retry.md
+++ b/docs/guides/retry.md
@@ -225,9 +225,9 @@ never wraps them. The retryable base class varies by library:
 
 When the server returns a non-download status (anything other than 200, 206, or
 416), pyhaul raises [`UnexpectedStatusError`][pyhaul._types.UnexpectedStatusError]
-with structured metadata — `status_code`, `headers`, and a convenience
-`is_transient` / `is_server_error` — so you can branch on status codes and honour
-`Retry-After` without parsing strings:
+with structured metadata — `status_code`, `headers`,
+`is_transient` / `is_server_error`, and parsed `retry_after_seconds` — so you can branch on status codes and honour
+`Retry-After` (delay seconds or HTTP-date) without manual parsing:
 
 === "httpx"
 
@@ -245,7 +245,7 @@ with structured metadata — `status_code`, `headers`, and a convenience
                 time.sleep(min(2**attempt, 30))
             except UnexpectedStatusError as exc:
                 if exc.is_transient:
-                    wait = int(exc.retry_after or 0) or min(2**attempt, 60)
+                    wait = exc.retry_after_seconds if exc.retry_after_seconds is not None else min(2**attempt, 60)
                     time.sleep(wait)
                 else:
                     raise  # 404, 403, etc. — not retryable
@@ -268,7 +268,7 @@ with structured metadata — `status_code`, `headers`, and a convenience
                     await asyncio.sleep(min(2**attempt, 30))
                 except UnexpectedStatusError as exc:
                     if exc.is_transient:
-                        wait = int(exc.retry_after or 0) or min(2**attempt, 60)
+                        wait = exc.retry_after_seconds if exc.retry_after_seconds is not None else min(2**attempt, 60)
                         await asyncio.sleep(wait)
                     else:
                         raise  # 404, 403, etc. — not retryable
@@ -292,7 +292,7 @@ with structured metadata — `status_code`, `headers`, and a convenience
                 time.sleep(min(2**attempt, 30))
             except UnexpectedStatusError as exc:
                 if exc.is_transient:
-                    wait = int(exc.retry_after or 0) or min(2**attempt, 60)
+                    wait = exc.retry_after_seconds if exc.retry_after_seconds is not None else min(2**attempt, 60)
                     time.sleep(wait)
                 else:
                     raise  # 404, 403, etc. — not retryable
@@ -314,7 +314,7 @@ with structured metadata — `status_code`, `headers`, and a convenience
                 time.sleep(min(2**attempt, 30))
             except UnexpectedStatusError as exc:
                 if exc.is_transient:
-                    wait = int(exc.retry_after or 0) or min(2**attempt, 60)
+                    wait = exc.retry_after_seconds if exc.retry_after_seconds is not None else min(2**attempt, 60)
                     time.sleep(wait)
                 else:
                     raise  # 404, 403, etc. — not retryable

--- a/docs/guides/retry.md
+++ b/docs/guides/retry.md
@@ -205,7 +205,7 @@ tenacity's async support works transparently with `haul_async`.
 | --- | --- | --- |
 | [`PartialHaulError`][pyhaul._types.PartialHaulError] | Yes | Stream ended early; progress saved to checkpoint |
 | Transport errors (timeout, connection reset) | Yes | Transient network issue — see table below |
-| [`UnexpectedStatusError`][pyhaul._types.UnexpectedStatusError] | Caller decides | `exc.is_transient` is True for 429/503, False for 404/403/etc. |
+| [`UnexpectedStatusError`][pyhaul._types.UnexpectedStatusError] | Caller decides | `exc.is_transient` is True for common temporary statuses (408, 425, 429, many 5xx, CDN codes); `exc.is_server_error` is True for any HTTP 5xx |
 | [`ServerMisconfiguredError`][pyhaul._types.ServerMisconfiguredError] | No | Server violates HTTP in a way that prevents safe resume |
 | [`DestinationError`][pyhaul._types.DestinationError] | No | Path problem — retrying won't fix it |
 | [`ControlFileError`][pyhaul._types.ControlFileError] | Auto-recovers | Corrupt checkpoint is discarded; next attempt starts fresh |
@@ -226,7 +226,7 @@ never wraps them. The retryable base class varies by library:
 When the server returns a non-download status (anything other than 200, 206, or
 416), pyhaul raises [`UnexpectedStatusError`][pyhaul._types.UnexpectedStatusError]
 with structured metadata — `status_code`, `headers`, and a convenience
-`is_transient` property — so you can branch on status codes and honour
+`is_transient` / `is_server_error` — so you can branch on status codes and honour
 `Retry-After` without parsing strings:
 
 === "httpx"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -70,8 +70,10 @@ state where a partially-written file sits at the final path.
 ## Resume
 
 To resume, call `haul()` again with the same destination. pyhaul reads the
-checkpoint, sends a `Range` request with `If-Range: <etag>`, and appends from
-where it left off:
+checkpoint and sends `Range` for the tail of the object. When the checkpoint
+holds a **strong** ETag, pyhaul also sends **`If-Range`** with that validator;
+weak or missing validators omit **`If-Range`** (byte-range preconditioning only
+applies to strong validators). It then appends from where it left off:
 
 ```python
 # Just call haul() again — it resumes automatically

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -28,7 +28,11 @@
     options:
       heading_level: 3
 
-::: pyhaul._types.ETag
+::: pyhaul.etag.EntityTag
+    options:
+      heading_level: 3
+
+::: pyhaul.etag.EMPTY_ETAG
     options:
       heading_level: 3
 
@@ -44,7 +48,15 @@ dedicated [TransportHeaders](headers.md) page — duplicated here it would colli
     options:
       heading_level: 3
 
-::: pyhaul._types.parse_etag
+::: pyhaul.etag.parse_etag
+    options:
+      heading_level: 3
+
+::: pyhaul.etag.format_entity_tag_for_http_header
+    options:
+      heading_level: 3
+
+::: pyhaul.etag.is_weak_validator
     options:
       heading_level: 3
 

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -21,7 +21,7 @@ HaulError
 | Exception | When | Retryable? |
 | --- | --- | --- |
 | `PartialHaulError` | Stream ended before all bytes arrived. | Yes — call `haul()` again; progress is saved |
-| `UnexpectedStatusError` | Server returned a non-download status (429, 503, 404, …). | Lets caller decide — check `exc.is_transient` |
+| `UnexpectedStatusError` | Server returned a non-download status (408, 429, 5xx, 404, …). | Lets caller decide — check `exc.is_transient` / `exc.is_server_error` |
 | `ServerMisconfiguredError` | Server violated HTTP in a way that prevents safe resume. | No |
 | `ContentRangeError` | 206 `Content-Range` doesn't match the requested range. | Often yes |
 | `ControlFileError` | `.part.ctrl` is corrupt or version-mismatched. | Auto-recovers — corrupt checkpoint is discarded on next attempt |

--- a/docs/reference/headers.md
+++ b/docs/reference/headers.md
@@ -53,7 +53,7 @@ h = TransportHeaders.from_pairs([
 ])
 
 repr(h)
-# "TransportHeaders({'content-type': 'text/html', 'authorization': '[redacted]'})"
+# "TransportHeaders([('content-type', 'text/html'), ('authorization', '[redacted]')])"
 
 h.to_safe_dict()
 # {'content-type': 'text/html', 'authorization': '[redacted]'}

--- a/docs/reference/spec.md
+++ b/docs/reference/spec.md
@@ -100,7 +100,11 @@ control file from causing the parser to misinterpret lengths or ETag strings.
 
 Supported Tags:
 
-- `1`: ETag (UTF-8 string)
+- `1`: ETag (UTF-8 string — RFC ``entity-tag`` text: ``"<opaque>"``,
+  ``W/"<opaque>"``, or ``*``, as produced by
+  :meth:`EntityTag.to_canonical <pyhaul.etag.EntityTag.to_canonical>`;
+  legacy bare tokens still load via
+  :meth:`EntityTag.from_canonical <pyhaul.etag.EntityTag.from_canonical>`)
 - `2`: Reported length (64-bit unsigned integer — server-claimed full size)
 - `3`: Tail Hash (32-byte SHA-256 binary digest of the current partial block)
 

--- a/src/pyhaul/__init__.py
+++ b/src/pyhaul/__init__.py
@@ -11,6 +11,7 @@ from pyhaul._types import (
     HaulError,
     HaulState,
     PartialHaulError,
+    ProbeResult,
     ServerMeta,
     ServerMisconfiguredError,
     UnexpectedStatusError,
@@ -19,6 +20,7 @@ from pyhaul._types import (
 )
 from pyhaul._version import __version__
 from pyhaul.async_engine import haul_async
+from pyhaul.async_probe import probe_async
 from pyhaul.engine import haul
 from pyhaul.etag import (
     EMPTY_ETAG,
@@ -28,6 +30,7 @@ from pyhaul.etag import (
     is_weak_validator,
     parse_etag,
 )
+from pyhaul.probe import probe
 
 __all__ = [
     "EMPTY_ETAG",
@@ -42,6 +45,7 @@ __all__ = [
     "HaulError",
     "HaulState",
     "PartialHaulError",
+    "ProbeResult",
     "ServerMeta",
     "ServerMisconfiguredError",
     "UnexpectedStatusError",
@@ -53,6 +57,8 @@ __all__ = [
     "is_weak_validator",
     "parse_etag",
     "parse_url",
+    "probe",
+    "probe_async",
     "register_async_adapter",
     "register_sync_adapter",
 ]

--- a/src/pyhaul/__init__.py
+++ b/src/pyhaul/__init__.py
@@ -2,11 +2,11 @@
 
 from pyhaul._session_dispatch import register_async_adapter, register_sync_adapter
 from pyhaul._types import (
+    AsyncProgressCallback,
     CompleteHaul,
     ContentRangeError,
     ControlFileError,
     DestinationError,
-    ETag,
     HashBuilder,
     HaulError,
     HaulState,
@@ -15,19 +15,29 @@ from pyhaul._types import (
     ServerMisconfiguredError,
     UnexpectedStatusError,
     Url,
-    parse_etag,
     parse_url,
 )
 from pyhaul._version import __version__
 from pyhaul.async_engine import haul_async
 from pyhaul.engine import haul
+from pyhaul.etag import (
+    EMPTY_ETAG,
+    EntityTag,
+    ETag,
+    format_entity_tag_for_http_header,
+    is_weak_validator,
+    parse_etag,
+)
 
 __all__ = [
+    "EMPTY_ETAG",
+    "AsyncProgressCallback",
     "CompleteHaul",
     "ContentRangeError",
     "ControlFileError",
     "DestinationError",
     "ETag",
+    "EntityTag",
     "HashBuilder",
     "HaulError",
     "HaulState",
@@ -37,8 +47,10 @@ __all__ = [
     "UnexpectedStatusError",
     "Url",
     "__version__",
+    "format_entity_tag_for_http_header",
     "haul",
     "haul_async",
+    "is_weak_validator",
     "parse_etag",
     "parse_url",
     "register_async_adapter",

--- a/src/pyhaul/_engine_common.py
+++ b/src/pyhaul/_engine_common.py
@@ -15,6 +15,7 @@ import os
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from http import HTTPStatus
 from pathlib import Path
 
 from pyhaul._types import (
@@ -50,12 +51,16 @@ datasync = getattr(os, "fdatasync", os.fsync)
 
 logger = logging.getLogger(__name__)
 
-_HTTP_200 = 200
-_HTTP_206 = 206
-_HTTP_416 = 416
-
 # Final responses when the underlying client chose not to follow (library default or explicit).
-_REDIRECT_STATUSES: frozenset[int] = frozenset({301, 302, 303, 307, 308})
+_REDIRECT_STATUSES: frozenset[int] = frozenset(
+    {
+        HTTPStatus.MOVED_PERMANENTLY,
+        HTTPStatus.FOUND,
+        HTTPStatus.SEE_OTHER,
+        HTTPStatus.TEMPORARY_REDIRECT,
+        HTTPStatus.PERMANENT_REDIRECT,
+    },
+)
 
 
 # ─── Dataclasses ──────────────────────────────────────────────────
@@ -209,13 +214,13 @@ def handle_response(
         },
     )
 
-    if status == _HTTP_416:
+    if status == HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE:
         return _on_416(headers, prep, state, resp_etag=resp_etag, content_type=resp_ct)
 
-    if status == _HTTP_206:
+    if status == HTTPStatus.PARTIAL_CONTENT:
         return _plan_206(headers, prep, state, resp_etag=resp_etag, content_type=resp_ct)
 
-    if status == _HTTP_200:
+    if status == HTTPStatus.OK:
         return _plan_200(headers, prep, state, resp_etag=resp_etag, content_type=resp_ct)
 
     if status in _REDIRECT_STATUSES:

--- a/src/pyhaul/_engine_common.py
+++ b/src/pyhaul/_engine_common.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from pyhaul._types import (
+    EMPTY_ETAG,
     CompleteHaul,
     ControlFileError,
     DestinationError,
@@ -28,6 +29,7 @@ from pyhaul._types import (
     ServerMisconfiguredError,
     UnexpectedStatusError,
     Url,
+    format_entity_tag_for_http_header,
     parse_etag,
     parse_url,
 )
@@ -121,7 +123,7 @@ def prepare_haul(
 
     start = cp.start if cp else 0
     cursor = cp.valid_length if cp else 0
-    stored_etag = cp.etag if cp else ETag("")
+    stored_etag = cp.etag if cp else EMPTY_ETAG
     hashes = cp.hashes if cp else []
     tail_hash = cp.tail_hash if cp else None
     block_size = cp.block_size if cp else 8 * 1024 * 1024
@@ -129,7 +131,29 @@ def prepare_haul(
     request_byte = start + cursor
     req_hdrs: dict[str, str] = {"Range": f"bytes={request_byte}-"}
     if stored_etag:
-        req_hdrs["If-Range"] = str(stored_etag)
+        if stored_etag.usable_for_byte_range_precondition:
+            req_hdrs["If-Range"] = format_entity_tag_for_http_header(stored_etag)
+        elif stored_etag.is_weak:
+            logger.warning(
+                "checkpoint stores weak ETag %r — cannot use it for If-Range resume "
+                "validation (weak validators are not defined for byte-identical range "
+                "preconditions per RFC 9110); sending Range without If-Range",
+                str(stored_etag),
+                extra={
+                    "pyhaul_stored_etag": str(stored_etag),
+                    "pyhaul_weak_etag_skip_if_range": True,
+                },
+            )
+        elif stored_etag.is_wildcard:
+            logger.warning(
+                "checkpoint stores wildcard ETag %r — cannot use If-Range for byte-range "
+                "preconditioning; sending Range without If-Range",
+                str(stored_etag),
+                extra={
+                    "pyhaul_stored_etag": str(stored_etag),
+                    "pyhaul_wildcard_etag_skip_if_range": True,
+                },
+            )
 
     merged = merge_headers(dict(user_headers or {}), {**DEFAULT_HEADERS, **req_hdrs})
     th = TransportHeaders.from_mapping(merged)
@@ -270,10 +294,41 @@ def _plan_206(
         raise ServerMisconfiguredError("206 with unsatisfied Content-Range")
     assert cr.start is not None  # noqa: S101 — type narrowing after is_unsatisfied guard
     if cr.start != prep.request_byte:
+        # Some origins respond with 206 but a satisfied Content-Range of the whole
+        # representation starting at 0 while ignoring Range — equivalent to sending
+        # 200 for the full body. Recover via _plan_200 only when the range spans the
+        # entire instance (start 0 .. instance_length-1).
+        if (
+            prep.request_byte > 0
+            and cr.start == 0
+            and cr.end is not None
+            and cr.instance_length is not None
+            and cr.instance_length > 0
+            and cr.end == cr.instance_length - 1
+        ):
+            logger.info(
+                "206 with satisfied Content-Range bytes 0-%s/%s while Range requested "
+                "byte offset %s — treating as full representation (mislabeled 206 / graceful "
+                "200 recovery)",
+                cr.end,
+                cr.instance_length,
+                prep.request_byte,
+                extra={
+                    "pyhaul_resume_cursor": prep.cursor,
+                    "pyhaul_request_byte": prep.request_byte,
+                },
+            )
+            return _plan_200(headers, prep, state, resp_etag=resp_etag, content_type=content_type)
+
         raise ServerMisconfiguredError(f"Content-Range start {cr.start} != requested {prep.request_byte}")
 
-    # BUG FIX: Verify ETag if server sent one.
-    if resp_etag and prep.stored_etag and resp_etag != prep.stored_etag:
+    # Strong, specific validators only — weak / wildcard checkpoint tags skip strict 206 equality.
+    if (
+        resp_etag
+        and prep.stored_etag
+        and prep.stored_etag.usable_for_byte_range_precondition
+        and resp_etag != prep.stored_etag
+    ):
         logger.debug(
             "ETag mismatch on 206, aborting",
             extra={
@@ -511,7 +566,7 @@ def _reset_checkpoint(ctrl_path: Path, start: int, block_size: int) -> None:
         start=start,
         extent=None,
         valid_length=0,
-        etag=ETag(""),
+        etag=EMPTY_ETAG,
         block_size=block_size,
         hashes=[],
         tail_hash=None,

--- a/src/pyhaul/_probe_common.py
+++ b/src/pyhaul/_probe_common.py
@@ -1,0 +1,290 @@
+"""Shared logic for :func:`~pyhaul.probe.probe` / :func:`~pyhaul.async_probe.probe_async`."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import cast
+
+from pyhaul._types import EMPTY_ETAG, ContentRangeError, ETag, ProbeResult, UnexpectedStatusError, parse_etag, parse_url
+from pyhaul.content_range import parse_content_range
+from pyhaul.headers import DEFAULT_HEADERS, merge_headers
+from pyhaul.transport._headers import TransportHeaders
+from pyhaul.transport.protocols import AsyncTransportResponse, TransportResponse
+from pyhaul.transport.types import TransportRequestOptions
+
+_HTTP_200 = 200
+_HTTP_206 = 206
+_HTTP_416 = 416
+_HTTP_REDIRECT = 300
+_HTTP_BAD_REQ = 400
+_DEFAULT_CHUNK = 1 << 16
+
+
+def _parse_content_length(raw: str | None) -> int | None:
+    """Parse ``Content-Length`` (same rules as :mod:`pyhaul._engine_common`)."""
+    if raw is None:
+        return None
+    s = raw.strip()
+    tokens = [t.strip() for t in s.split(",") if t.strip()]
+    if not tokens or any(not t.isdigit() for t in tokens):
+        return None
+    if len(set(tokens)) > 1:
+        return None
+    return int(tokens[0])
+
+
+def _accept_ranges_bytes(headers: TransportHeaders) -> bool:
+    """Return True when ``Accept-Ranges`` is ``bytes``."""
+    raw = headers.get("Accept-Ranges") or ""
+    return raw.strip().lower() == "bytes"
+
+
+def _length_discovery_present(headers: TransportHeaders) -> bool:
+    """True when ``Content-Range`` or parseable ``Content-Length`` hints at size."""
+    cr = headers.get("Content-Range") or ""
+    if cr.strip():
+        return True
+    return _parse_content_length(headers.get("Content-Length")) is not None
+
+
+def _pypdl_style_metadata_complete(headers: TransportHeaders, *, head_was_2xx: bool) -> bool:
+    """Whether HEAD returned enough metadata that pypdl would skip a ranged GET."""
+    if not head_was_2xx:
+        return False
+    etag = (headers.get("ETag") or "").strip()
+    cd = (headers.get("Content-Disposition") or "").strip()
+    return bool(
+        _accept_ranges_bytes(headers) and etag and cd and _length_discovery_present(headers),
+    )
+
+
+def _total_length_from_status(status: int, headers: TransportHeaders) -> int | None:
+    """Infer full entity length from *status* and *headers* when possible."""
+    if status == _HTTP_200:
+        return _parse_content_length(headers.get("Content-Length"))
+    if status not in (_HTTP_206, _HTTP_416):
+        return None
+    cr_raw = headers.get("Content-Range")
+    if not cr_raw:
+        return None
+    try:
+        cr = parse_content_range(cr_raw)
+    except ContentRangeError:
+        return None
+    if status == _HTTP_416:
+        return cr.instance_length if cr.is_unsatisfied else None
+    return cr.instance_length
+
+
+def _unexpected(status: int, headers: TransportHeaders) -> UnexpectedStatusError:
+    """Build :class:`UnexpectedStatusError` for *status* and *headers*."""
+    return UnexpectedStatusError(status_code=status, headers=headers)
+
+
+def _finalize_allowed_status(status: int, headers: TransportHeaders) -> None:
+    """Raise if *status* is not an acceptable terminal probe response."""
+    if status in (_HTTP_200, _HTTP_206):
+        return
+    if status == _HTTP_416:
+        cr_raw = headers.get("Content-Range") or ""
+        if cr_raw.strip():
+            try:
+                cr = parse_content_range(cr_raw)
+            except ContentRangeError:
+                raise _unexpected(status, headers) from None
+            if cr.is_unsatisfied and cr.instance_length is not None:
+                return
+        raise _unexpected(status, headers)
+    if status >= _HTTP_BAD_REQ:
+        raise _unexpected(status, headers)
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeSnapshot:
+    """Fields extracted from one HEAD or GET response."""
+
+    status_code: int
+    total_length: int | None
+    etag: ETag
+    last_modified: str
+    content_type: str
+    content_disposition: str
+    accept_ranges_bytes: bool
+
+
+def snapshot_from_response(status: int, headers: TransportHeaders) -> ProbeSnapshot:
+    """Build a :class:`ProbeSnapshot` from response *status* and *headers*."""
+    return ProbeSnapshot(
+        status_code=status,
+        total_length=_total_length_from_status(status, headers),
+        etag=parse_etag(headers.get("ETag", "")),
+        last_modified=headers.get("Last-Modified") or "",
+        content_type=headers.get("Content-Type") or "",
+        content_disposition=headers.get("Content-Disposition") or "",
+        accept_ranges_bytes=_accept_ranges_bytes(headers),
+    )
+
+
+def merge_snapshots(primary: ProbeSnapshot, secondary: ProbeSnapshot) -> ProbeSnapshot:
+    """Prefer non-empty / more informative values from *secondary* (ranged GET)."""
+    lm = secondary.last_modified if secondary.last_modified.strip() else primary.last_modified
+    ct = secondary.content_type if secondary.content_type.strip() else primary.content_type
+    cd = secondary.content_disposition if secondary.content_disposition.strip() else primary.content_disposition
+    etag = secondary.etag if secondary.etag != EMPTY_ETAG else primary.etag
+    tot = secondary.total_length if secondary.total_length is not None else primary.total_length
+    return ProbeSnapshot(
+        status_code=secondary.status_code,
+        total_length=tot,
+        etag=etag,
+        last_modified=lm,
+        content_type=ct,
+        content_disposition=cd,
+        accept_ranges_bytes=secondary.accept_ranges_bytes or primary.accept_ranges_bytes,
+    )
+
+
+def probe_base_headers(user_headers: Mapping[str, str] | None) -> TransportHeaders:
+    """Merge *user_headers* with pyhaul defaults (no ``Range``)."""
+    merged = merge_headers(dict(user_headers or {}), dict(DEFAULT_HEADERS))
+    return TransportHeaders.from_mapping(merged)
+
+
+def drain_sync(resp: TransportResponse, *, chunk_size: int = _DEFAULT_CHUNK) -> None:
+    """Consume the full raw body of *resp* (sync)."""
+    for _ in resp.iter_raw_bytes(chunk_size=chunk_size):
+        pass
+
+
+async def drain_async(resp: AsyncTransportResponse, *, chunk_size: int = _DEFAULT_CHUNK) -> None:
+    """Consume the full raw body of *resp* (async)."""
+    async for _ in resp.aiter_raw_bytes(chunk_size=chunk_size):
+        pass
+
+
+def run_probe_sync(
+    transport: object,
+    url: str,
+    *,
+    headers: Mapping[str, str] | None,
+    options: TransportRequestOptions | None,
+) -> ProbeResult:
+    """Execute the probe sequence synchronously (HEAD then optional ranged GET)."""
+    from pyhaul.transport.protocols import TransportSession
+
+    if not isinstance(transport, TransportSession):
+        msg = "client must coerce to TransportSession (same adapters as haul)"
+        raise TypeError(msg)
+
+    parsed = parse_url(url)
+    prepared_head = transport.prepare_headers(probe_base_headers(headers))
+
+    snap: ProbeSnapshot | None = None
+    ranged_get_used = False
+    head_attempted = False
+    head_status_code: int | None = None
+    head_headers_saved: TransportHeaders | None = None
+    skip_get = False
+
+    with transport.stream_head(parsed, headers=dict(prepared_head.items()), options=options) as head_resp:
+        head_attempted = True
+        head_status_code = head_resp.status_code
+        hh = head_resp.headers
+        if _HTTP_200 <= head_resp.status_code < _HTTP_REDIRECT:
+            head_headers_saved = hh
+            snap = snapshot_from_response(head_resp.status_code, hh)
+            skip_get = _pypdl_style_metadata_complete(hh, head_was_2xx=True)
+
+    if not skip_get:
+        ranged_get_used = True
+        probe_req = merge_headers(
+            dict(headers or {}),
+            {**DEFAULT_HEADERS, "Range": "bytes=0-0"},
+        )
+        th = transport.prepare_headers(TransportHeaders.from_mapping(probe_req))
+        with transport.stream_get(parsed, headers=dict(th.items()), options=options) as resp:
+            snap_get = snapshot_from_response(resp.status_code, resp.headers)
+            drain_sync(resp)
+            _finalize_allowed_status(resp.status_code, resp.headers)
+            snap_final = merge_snapshots(snap, snap_get) if snap is not None else snap_get
+    else:
+        _finalize_allowed_status(cast("ProbeSnapshot", snap).status_code, cast("TransportHeaders", head_headers_saved))
+        snap_final = cast("ProbeSnapshot", snap)
+
+    return ProbeResult(
+        url=parsed,
+        status_code=snap_final.status_code,
+        total_length=snap_final.total_length,
+        etag=snap_final.etag,
+        last_modified=snap_final.last_modified,
+        content_type=snap_final.content_type,
+        content_disposition=snap_final.content_disposition,
+        accept_ranges_bytes=snap_final.accept_ranges_bytes,
+        head_attempted=head_attempted,
+        head_status_code=head_status_code,
+        ranged_get_used=ranged_get_used,
+    )
+
+
+async def run_probe_async(
+    transport: object,
+    url: str,
+    *,
+    headers: Mapping[str, str] | None,
+    options: TransportRequestOptions | None,
+) -> ProbeResult:
+    """Execute the probe sequence asynchronously."""
+    from pyhaul.transport.protocols import AsyncTransportSession
+
+    if not isinstance(transport, AsyncTransportSession):
+        msg = "client must coerce to AsyncTransportSession (same adapters as haul_async)"
+        raise TypeError(msg)
+
+    parsed = parse_url(url)
+    prepared_head = transport.prepare_headers(probe_base_headers(headers))
+
+    snap: ProbeSnapshot | None = None
+    ranged_get_used = False
+    head_attempted = False
+    head_status_code: int | None = None
+    head_headers_saved: TransportHeaders | None = None
+    skip_get = False
+
+    async with transport.stream_head(parsed, headers=dict(prepared_head.items()), options=options) as head_resp:
+        head_attempted = True
+        head_status_code = head_resp.status_code
+        hh = head_resp.headers
+        if _HTTP_200 <= head_resp.status_code < _HTTP_REDIRECT:
+            head_headers_saved = hh
+            snap = snapshot_from_response(head_resp.status_code, hh)
+            skip_get = _pypdl_style_metadata_complete(hh, head_was_2xx=True)
+
+    if not skip_get:
+        ranged_get_used = True
+        probe_req = merge_headers(
+            dict(headers or {}),
+            {**DEFAULT_HEADERS, "Range": "bytes=0-0"},
+        )
+        th = transport.prepare_headers(TransportHeaders.from_mapping(probe_req))
+        async with transport.stream_get(parsed, headers=dict(th.items()), options=options) as resp:
+            snap_get = snapshot_from_response(resp.status_code, resp.headers)
+            await drain_async(resp)
+            _finalize_allowed_status(resp.status_code, resp.headers)
+            snap_final = merge_snapshots(snap, snap_get) if snap is not None else snap_get
+    else:
+        _finalize_allowed_status(cast("ProbeSnapshot", snap).status_code, cast("TransportHeaders", head_headers_saved))
+        snap_final = cast("ProbeSnapshot", snap)
+
+    return ProbeResult(
+        url=parsed,
+        status_code=snap_final.status_code,
+        total_length=snap_final.total_length,
+        etag=snap_final.etag,
+        last_modified=snap_final.last_modified,
+        content_type=snap_final.content_type,
+        content_disposition=snap_final.content_disposition,
+        accept_ranges_bytes=snap_final.accept_ranges_bytes,
+        head_attempted=head_attempted,
+        head_status_code=head_status_code,
+        ranged_get_used=ranged_get_used,
+    )

--- a/src/pyhaul/_probe_common.py
+++ b/src/pyhaul/_probe_common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from http import HTTPStatus
 from typing import cast
 
 from pyhaul._types import EMPTY_ETAG, ContentRangeError, ETag, ProbeResult, UnexpectedStatusError, parse_etag, parse_url
@@ -13,11 +14,6 @@ from pyhaul.transport._headers import TransportHeaders
 from pyhaul.transport.protocols import AsyncTransportResponse, TransportResponse
 from pyhaul.transport.types import TransportRequestOptions
 
-_HTTP_200 = 200
-_HTTP_206 = 206
-_HTTP_416 = 416
-_HTTP_REDIRECT = 300
-_HTTP_BAD_REQ = 400
 _DEFAULT_CHUNK = 1 << 16
 
 
@@ -61,9 +57,9 @@ def _pypdl_style_metadata_complete(headers: TransportHeaders, *, head_was_2xx: b
 
 def _total_length_from_status(status: int, headers: TransportHeaders) -> int | None:
     """Infer full entity length from *status* and *headers* when possible."""
-    if status == _HTTP_200:
+    if status == HTTPStatus.OK:
         return _parse_content_length(headers.get("Content-Length"))
-    if status not in (_HTTP_206, _HTTP_416):
+    if status not in (HTTPStatus.PARTIAL_CONTENT, HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE):
         return None
     cr_raw = headers.get("Content-Range")
     if not cr_raw:
@@ -72,7 +68,7 @@ def _total_length_from_status(status: int, headers: TransportHeaders) -> int | N
         cr = parse_content_range(cr_raw)
     except ContentRangeError:
         return None
-    if status == _HTTP_416:
+    if status == HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE:
         return cr.instance_length if cr.is_unsatisfied else None
     return cr.instance_length
 
@@ -84,9 +80,9 @@ def _unexpected(status: int, headers: TransportHeaders) -> UnexpectedStatusError
 
 def _finalize_allowed_status(status: int, headers: TransportHeaders) -> None:
     """Raise if *status* is not an acceptable terminal probe response."""
-    if status in (_HTTP_200, _HTTP_206):
+    if status in (HTTPStatus.OK, HTTPStatus.PARTIAL_CONTENT):
         return
-    if status == _HTTP_416:
+    if status == HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE:
         cr_raw = headers.get("Content-Range") or ""
         if cr_raw.strip():
             try:
@@ -96,7 +92,7 @@ def _finalize_allowed_status(status: int, headers: TransportHeaders) -> None:
             if cr.is_unsatisfied and cr.instance_length is not None:
                 return
         raise _unexpected(status, headers)
-    if status >= _HTTP_BAD_REQ:
+    if status >= HTTPStatus.BAD_REQUEST:
         raise _unexpected(status, headers)
 
 
@@ -190,7 +186,7 @@ def run_probe_sync(
         head_attempted = True
         head_status_code = head_resp.status_code
         hh = head_resp.headers
-        if _HTTP_200 <= head_resp.status_code < _HTTP_REDIRECT:
+        if HTTPStatus.OK <= head_resp.status_code < HTTPStatus.MULTIPLE_CHOICES:
             head_headers_saved = hh
             snap = snapshot_from_response(head_resp.status_code, hh)
             skip_get = _pypdl_style_metadata_complete(hh, head_was_2xx=True)
@@ -254,7 +250,7 @@ async def run_probe_async(
         head_attempted = True
         head_status_code = head_resp.status_code
         hh = head_resp.headers
-        if _HTTP_200 <= head_resp.status_code < _HTTP_REDIRECT:
+        if HTTPStatus.OK <= head_resp.status_code < HTTPStatus.MULTIPLE_CHOICES:
             head_headers_saved = hh
             snap = snapshot_from_response(head_resp.status_code, hh)
             skip_get = _pypdl_style_metadata_complete(hh, head_was_2xx=True)

--- a/src/pyhaul/_types.py
+++ b/src/pyhaul/_types.py
@@ -8,6 +8,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC
 from email.utils import parsedate_to_datetime
+from http import HTTPStatus
 from pathlib import Path
 from typing import NewType
 from urllib.parse import urlparse
@@ -42,21 +43,18 @@ _URL_SCHEMES: frozenset[str] = frozenset({"http", "https"})
 # or rate limiting — conservative superset for default retry hints.
 _TRANSIENT_HTTP_STATUSES: frozenset[int] = frozenset(
     {
-        408,  # Request Timeout
-        425,  # Too Early
-        429,  # Too Many Requests
-        500,  # Internal Server Error
-        502,  # Bad Gateway
-        503,  # Service Unavailable
-        504,  # Gateway Timeout
+        HTTPStatus.REQUEST_TIMEOUT,
+        HTTPStatus.TOO_EARLY,
+        HTTPStatus.TOO_MANY_REQUESTS,
+        HTTPStatus.INTERNAL_SERVER_ERROR,
+        HTTPStatus.BAD_GATEWAY,
+        HTTPStatus.SERVICE_UNAVAILABLE,
+        HTTPStatus.GATEWAY_TIMEOUT,
         520,  # Cloudflare: unknown error
         522,  # Cloudflare: connection timed out
         524,  # Cloudflare: a timeout occurred
     },
 )
-
-_HTTP_SERVER_ERROR_MIN = 500
-_HTTP_SERVER_ERROR_MAX = 599
 
 
 def _retry_after_raw_to_seconds(
@@ -268,7 +266,7 @@ class UnexpectedStatusError(HaulError):
     @property
     def is_server_error(self) -> bool:
         """True for HTTP 5xx responses (status ``500`` ≤ code ≤ ``599``)."""
-        return _HTTP_SERVER_ERROR_MIN <= self.status_code <= _HTTP_SERVER_ERROR_MAX
+        return self.status_code // 100 == 5  # noqa: PLR2004 -- RFC 9110 status class 5 (server error)
 
     @property
     def retry_after(self) -> str | None:

--- a/src/pyhaul/_types.py
+++ b/src/pyhaul/_types.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import hashlib
+import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import UTC
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import NewType
 from urllib.parse import urlparse
@@ -58,6 +62,42 @@ _TRANSIENT_HTTP_STATUSES: frozenset[int] = frozenset(
 
 _HTTP_SERVER_ERROR_MIN = 500
 _HTTP_SERVER_ERROR_MAX = 599
+
+
+def _retry_after_raw_to_seconds(
+    raw: str | None,
+    *,
+    now: Callable[[], float] | None = None,
+) -> float | None:
+    """Parse ``Retry-After`` into seconds after ``now()`` — RFC 9110 §10.2.3 form.
+
+    Tries ``HTTP-date`` first (same order as common clients), then ``delay-seconds``.
+    Returns ``None`` if absent or unparsable. HTTP-dates in the past map to ``0.0``.
+    Does **not** cap values — callers choose retry policy.
+    """
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    clock = time.time if now is None else now
+
+    try:
+        dt = parsedate_to_datetime(stripped)
+    except (TypeError, ValueError):
+        dt = None
+    if dt is not None:
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        delta = dt.timestamp() - clock()
+        out = max(0.0, delta)
+        return float(out)
+
+    if stripped.isdigit():
+        sec = int(stripped)
+        return float(sec)
+
+    return None
 
 
 def parse_url(raw: str) -> Url:
@@ -213,8 +253,17 @@ class UnexpectedStatusError(HaulError):
 
     @property
     def retry_after(self) -> str | None:
-        """Value of the ``Retry-After`` header, if present."""
+        """Raw ``Retry-After`` header value, if present (seconds or HTTP-date string)."""
         return self.headers.get("Retry-After")
+
+    @property
+    def retry_after_seconds(self) -> float | None:
+        """Seconds until retry per ``Retry-After``, or ``None`` if absent/unparsable.
+
+        Accepts ``delay-seconds`` (integer) and ``HTTP-date`` forms (RFC 9110 §10.2.3).
+        For dates in the past, returns ``0.0``. Parsing only — pyhaul does not retry or cap sleeps.
+        """
+        return _retry_after_raw_to_seconds(self.retry_after)
 
 
 class ContentRangeError(HaulError):

--- a/src/pyhaul/_types.py
+++ b/src/pyhaul/_types.py
@@ -131,6 +131,42 @@ class ServerMeta:
     content_type: str = ""
 
 
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ProbeResult:
+    """Structured remote metadata from :func:`~pyhaul.probe.probe` / :func:`~pyhaul.async_probe.probe_async`.
+
+    The probe sequence mirrors common CDN/origin behaviour: send ``HEAD``, then — when
+    metadata is still incomplete — issue ``GET`` with ``Range: bytes=0-0`` (see pypdl-style
+    discovery). Values are best-effort hints for planners (concurrent range shards,
+    progress UI); they are not a substitute for download-time validation.
+    """
+
+    url: Url
+    status_code: int
+    """HTTP status from the response that supplied the merged snapshot (usually GET)."""
+
+    total_length: int | None
+    """Total entity length when inferable from ``Content-Length`` or ``Content-Range``."""
+
+    etag: ETag
+    last_modified: str
+    content_type: str
+    content_disposition: str
+    """Raw ``Content-Disposition`` field value, if any."""
+
+    accept_ranges_bytes: bool
+    """True when ``Accept-Ranges: bytes`` is advertised."""
+
+    head_attempted: bool
+    head_status_code: int | None
+    ranged_get_used: bool
+
+    @property
+    def supports_concurrent_byte_ranges(self) -> bool:
+        """Whether byte-range sharding is plausible: ranges supported and size known."""
+        return self.accept_ranges_bytes and self.total_length is not None
+
+
 @dataclass(slots=True)
 class HaulState:
     """Mutable progress bag updated in-place by ``haul()`` / ``haul_async()``.

--- a/src/pyhaul/_types.py
+++ b/src/pyhaul/_types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC
 from email.utils import parsedate_to_datetime
@@ -12,7 +12,15 @@ from pathlib import Path
 from typing import NewType
 from urllib.parse import urlparse
 
+import pyhaul.etag as _etag
 from pyhaul.transport._headers import TransportHeaders
+
+EMPTY_ETAG = _etag.EMPTY_ETAG
+ETag = _etag.ETag
+EntityTag = _etag.EntityTag
+format_entity_tag_for_http_header = _etag.format_entity_tag_for_http_header
+is_weak_validator = _etag.is_weak_validator
+parse_etag = _etag.parse_etag
 
 ByteOffset = NewType("ByteOffset", int)
 """Absolute byte offset from the start of the download target."""
@@ -23,25 +31,12 @@ ByteLength = NewType("ByteLength", int)
 Url = NewType("Url", str)
 """An http(s) URL that has passed :func:`parse_url`."""
 
-ETag = NewType("ETag", str)
-"""An HTTP ETag value (possibly empty) that has passed :func:`parse_etag`.
-
-Stored verbatim as the server sent it — quotes and optional ``W/`` prefix
-included — so that it can be echoed back in ``If-Range`` / ``If-Match``
-byte-for-byte. An empty string means "no ETag for this resource".
-"""
-
-EMPTY_ETAG: ETag = ETag("")
-"""Shared "no ETag" singleton. Used as the default for signatures where
-inline ``ETag("")`` would trip B008."""
-
 EMPTY_URL: Url = Url("")
 """Shared "no URL yet" sentinel for components constructed before the
 downloader has a parsed URL to hand them (e.g. tests, trackers built
 for size bookkeeping only)."""
 
 _URL_SCHEMES: frozenset[str] = frozenset({"http", "https"})
-_MIN_QUOTED_ETAG_LEN = 2  # two DQUOTEs wrap any valid entity-tag
 
 # Status codes CDNs and origins often use for temporary overload, upstream failure,
 # or rate limiting — conservative superset for default retry hints.
@@ -120,27 +115,6 @@ def parse_url(raw: str) -> Url:
     return Url(raw)
 
 
-def parse_etag(raw: object) -> ETag:
-    """Normalize a raw ETag header value into an :data:`ETag`.
-
-    Strips surrounding whitespace. Empty input becomes ``ETag("")`` to
-    represent "no ETag". Values that clearly aren't well-formed
-    entity-tags (per RFC 7232: optional ``W/`` then a quoted string) are
-    also treated as absent, since echoing them back in ``If-Range`` /
-    ``If-Match`` would be unsafe. Non-string input raises
-    :class:`TypeError`.
-    """
-    if not isinstance(raw, str):
-        raise TypeError(f"etag must be str, got {type(raw).__name__}")
-    stripped = raw.strip()
-    if not stripped:
-        return EMPTY_ETAG
-    candidate = stripped.removeprefix("W/")
-    if len(candidate) < _MIN_QUOTED_ETAG_LEN or not candidate.startswith('"') or not candidate.endswith('"'):
-        return EMPTY_ETAG
-    return ETag(stripped)
-
-
 @dataclass(frozen=True, slots=True, kw_only=True)
 class ServerMeta:
     """Typed view of the response headers pyhaul cares about.
@@ -183,6 +157,15 @@ class HaulState:
     reported_length: int | None = None
     block_size: int = 8 * 1024 * 1024
     hashes: list[bytes] = field(default_factory=list[bytes])
+
+
+AsyncProgressCallback = Callable[[HaulState], None | Awaitable[None]]
+"""Progress hook for :func:`~pyhaul.async_engine.haul_async`.
+
+May be an ordinary function (returns ``None``) or return an awaitable
+(e.g. ``async def`` without awaiting it yourself); the engine awaits it
+when applicable so callers need not ``asyncio.create_task`` each chunk.
+"""
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -301,9 +284,6 @@ class HashBuilder:
         self.block_size = block_size
         self.completed_hashes = initial_hashes or []
         self._current_hash = hashlib.sha256()
-        self._total_pos = sum(len(h) for h in self.completed_hashes) * block_size  # inaccurate if we resumed at 0
-        # Actually, let's keep it simpler. We assume we are fed bytes sequentially
-        # starting from some offset.
         self._block_pos = 0  # bytes into the current block
 
     @property

--- a/src/pyhaul/_types.py
+++ b/src/pyhaul/_types.py
@@ -39,6 +39,26 @@ for size bookkeeping only)."""
 _URL_SCHEMES: frozenset[str] = frozenset({"http", "https"})
 _MIN_QUOTED_ETAG_LEN = 2  # two DQUOTEs wrap any valid entity-tag
 
+# Status codes CDNs and origins often use for temporary overload, upstream failure,
+# or rate limiting — conservative superset for default retry hints.
+_TRANSIENT_HTTP_STATUSES: frozenset[int] = frozenset(
+    {
+        408,  # Request Timeout
+        425,  # Too Early
+        429,  # Too Many Requests
+        500,  # Internal Server Error
+        502,  # Bad Gateway
+        503,  # Service Unavailable
+        504,  # Gateway Timeout
+        520,  # Cloudflare: unknown error
+        522,  # Cloudflare: connection timed out
+        524,  # Cloudflare: a timeout occurred
+    },
+)
+
+_HTTP_SERVER_ERROR_MIN = 500
+_HTTP_SERVER_ERROR_MAX = 599
+
 
 def parse_url(raw: str) -> Url:
     """Validate *raw* as an http(s) URL and brand it as :data:`Url`.
@@ -178,8 +198,18 @@ class UnexpectedStatusError(HaulError):
 
     @property
     def is_transient(self) -> bool:
-        """``True`` for 429 (Too Many Requests) and 503 (Service Unavailable)."""
-        return self.status_code in {429, 503}
+        """True when the status usually indicates a temporary condition worth retrying.
+
+        Includes common overload / upstream / CDN signals (e.g. ``408``, ``425``,
+        ``429``, ``5xx`` gateway and origin errors, and Cloudflare ``520``/``522``/``524``).
+        For any HTTP 5xx without branching on this set, see :attr:`is_server_error`.
+        """
+        return self.status_code in _TRANSIENT_HTTP_STATUSES
+
+    @property
+    def is_server_error(self) -> bool:
+        """True for HTTP 5xx responses (status ``500`` ≤ code ≤ ``599``)."""
+        return _HTTP_SERVER_ERROR_MIN <= self.status_code <= _HTTP_SERVER_ERROR_MAX
 
     @property
     def retry_after(self) -> str | None:

--- a/src/pyhaul/async_engine.py
+++ b/src/pyhaul/async_engine.py
@@ -4,18 +4,27 @@ Async mirror of :mod:`pyhaul.engine`.  All non-I/O logic is shared via
 :mod:`pyhaul._engine_common`; only the session context manager and the
 chunk iterator differ (``async with`` / ``async for``).
 
-Blocking disk I/O (``fdatasync``, checkpoint writes) is offloaded to the
-default executor via :func:`asyncio.loop.run_in_executor` so the event
-loop stays responsive for other tasks during periodic flushes.
+Blocking disk preparation (:func:`~pyhaul._engine_common.prepare_haul`),
+opening/preallocating the ``.part`` file (:func:`~pyhaul._engine_common.open_part_file`),
+HTTP ``416`` completion handling (including tree-hash of large ``.part`` files via
+:func:`~pyhaul._engine_common.handle_response`), post-download finalization
+(:func:`~pyhaul._engine_common.after_stream` — stat / truncate / rename / unlink),
+and ``fdatasync`` / checkpoint writes (including the best-effort dirty flush and
+close on ``TransportError``, ``asyncio.CancelledError``, or other abnormal exits in ``_flush_dirty_and_close``)
+use :func:`asyncio.loop.run_in_executor`
+(the default :class:`~concurrent.futures.ThreadPoolExecutor`) so the event loop
+stays responsive under concurrent downloads, slow filesystems, or streaming flushes.
 """
 
 from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
+import inspect
 import logging
 import os
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from pathlib import Path
 
 from pyhaul._engine_common import (
@@ -31,11 +40,19 @@ from pyhaul._engine_common import (
     save_checkpoint,
 )
 from pyhaul._session_dispatch import coerce_async_session
-from pyhaul._types import CompleteHaul, HaulState, PartialHaulError
+from pyhaul._types import (
+    AsyncProgressCallback,
+    CompleteHaul,
+    HaulState,
+    PartialHaulError,
+)
 from pyhaul.transport.errors import TransportConnectionError, TransportError
 from pyhaul.transport.protocols import AsyncTransportSession
 
 logger = logging.getLogger(__name__)
+
+# HTTP 416 Range Not Satisfiable — must match ``_engine_common._HTTP_416``.
+_HTTP_RANGE_NOT_SATISFIABLE = 416
 
 
 def _sync_flush(fd: int, plan: StreamPlan, prep: PrepareHaul) -> None:
@@ -80,7 +97,13 @@ def _flush_dirty_and_close(fd: int, plan: StreamPlan, prep: PrepareHaul) -> None
             os.close(fd)
 
 
-async def haul_async(  # noqa: C901 — stream loop + transport/error paths; keep linear
+async def _maybe_await_progress(cb: AsyncProgressCallback, state: HaulState) -> None:
+    out = cb(state)
+    if inspect.isawaitable(out):
+        await out
+
+
+async def haul_async(  # noqa: C901, PLR0912, PLR0915 — stream loop + transport/error paths; keep linear
     url: str,
     client: AsyncTransportSession | object,
     *,
@@ -89,7 +112,7 @@ async def haul_async(  # noqa: C901 — stream loop + transport/error paths; kee
     state: HaulState | None = None,
     chunk_size: int = DEFAULT_CHUNK,
     flush_every: int = DEFAULT_FLUSH,
-    on_progress: Callable[[HaulState], None] | None = None,
+    on_progress: AsyncProgressCallback | None = None,
 ) -> CompleteHaul:
     """Async equivalent of :func:`pyhaul.engine.haul`.
 
@@ -105,8 +128,11 @@ async def haul_async(  # noqa: C901 — stream loop + transport/error paths; kee
     throughout the download — always accurate regardless of how the
     function exits.
 
-    *on_progress*, if set, is called after each chunk (synchronous
-    callback; same contract as :func:`pyhaul.engine.haul`).
+    *on_progress*, if set, is called after each chunk.  It may be an
+    ordinary synchronous callable or return an awaitable (for example
+    an ``async def``); when the return value is awaitable, it is
+    awaited before the next chunk is read.  :func:`pyhaul.engine.haul`
+    accepts only synchronous callbacks.
 
     Returns :class:`CompleteHaul` on success.  Raises
     :class:`PartialHaulError` when the stream ends before all bytes
@@ -118,15 +144,31 @@ async def haul_async(  # noqa: C901 — stream loop + transport/error paths; kee
         state = HaulState()
     transport = coerce_async_session(client)
 
-    prep = prepare_haul(url, dest, user_headers=headers)
+    loop = asyncio.get_running_loop()
+    prep = await loop.run_in_executor(
+        None,
+        functools.partial(prepare_haul, url, dest, user_headers=headers),
+    )
+
     prepare_fn = getattr(transport, "prepare_headers", None)
     final_headers = prepare_fn(prep.merged_headers) if prepare_fn else prep.merged_headers
 
-    loop = asyncio.get_running_loop()
-
     try:
         async with transport.stream_get(prep.parsed_url, headers=final_headers) as resp:
-            action = handle_response(resp.status_code, resp.headers, prep, state)
+            # 416 → _on_416 may SHA-hash multi-GB .part files before finalize — offload.
+            if resp.status_code == _HTTP_RANGE_NOT_SATISFIABLE:
+                action = await loop.run_in_executor(
+                    None,
+                    functools.partial(
+                        handle_response,
+                        resp.status_code,
+                        resp.headers,
+                        prep,
+                        state,
+                    ),
+                )
+            else:
+                action = handle_response(resp.status_code, resp.headers, prep, state)
 
             if not isinstance(action, StreamPlan):
                 return action
@@ -136,13 +178,15 @@ async def haul_async(  # noqa: C901 — stream loop + transport/error paths; kee
                 "Beginning response body stream",
                 extra={"pyhaul_part_path": str(prep.part_path)},
             )
-            fd = open_part_file(plan, prep.part_path)
+            fd = await loop.run_in_executor(
+                None,
+                functools.partial(open_part_file, plan, prep.part_path),
+            )
             # Once True, the executor finalizer owns *fd* and is solely
-            # responsible for closing it.  The event-loop-side fallback
-            # close in the outer ``finally`` then becomes a no-op.  This
-            # prevents a cancellation race where the loop thread closes
-            # *fd* while a queued executor task is still calling
-            # ``datasync(fd)`` on it (EBADF).
+            # responsible for closing it.  ``finally`` below may call
+            # ``_flush_dirty_and_close`` if the stream exits without a finisher—
+            # preventing a cancellation race where the loop thread closes *fd*
+            # while ``datasync(fd)`` is still running (EBADF).
             fd_finalized_by_executor = False
             try:
                 async for chunk in resp.aiter_raw_bytes(chunk_size=chunk_size):
@@ -160,16 +204,7 @@ async def haul_async(  # noqa: C901 — stream loop + transport/error paths; kee
                         plan.bytes_since_flush = 0
 
                     if on_progress is not None:
-                        on_progress(state)
-
-                # Hand *fd* over to the executor for the final datasync +
-                # close.  The flag is set BEFORE the await so a
-                # cancellation here does not race the executor: the
-                # worker thread runs to completion and closes *fd*
-                # serially after datasync, with no concurrent close
-                # from the loop thread.
-                fd_finalized_by_executor = True
-                await loop.run_in_executor(None, _datasync_and_close, fd)
+                        await _maybe_await_progress(on_progress, state)
             except TransportError as exc:
                 fd_finalized_by_executor = True
                 await loop.run_in_executor(
@@ -180,16 +215,37 @@ async def haul_async(  # noqa: C901 — stream loop + transport/error paths; kee
                     prep,
                 )
                 raise PartialHaulError("connection lost during stream") from exc
+            except asyncio.CancelledError:
+                # Persist bytes written since the last periodic flush so cancel-resume
+                # matches abrupt-exit checkpoint semantics.
+                fd_finalized_by_executor = True
+                await loop.run_in_executor(
+                    None,
+                    _flush_dirty_and_close,
+                    fd,
+                    plan,
+                    prep,
+                )
+                raise
+            else:
+                # Normal stream end: final datasync + close on the executor thread.
+                fd_finalized_by_executor = True
+                await loop.run_in_executor(None, _datasync_and_close, fd)
             finally:
                 if not fd_finalized_by_executor:
-                    # Reachable only if a synchronous error occurred
-                    # between opening *fd* and any executor handoff.
-                    # Safe to close on the loop thread because no
-                    # executor task is in flight against this fd.
-                    with contextlib.suppress(OSError):
-                        os.close(fd)
+                    await loop.run_in_executor(
+                        None,
+                        _flush_dirty_and_close,
+                        fd,
+                        plan,
+                        prep,
+                    )
+                    fd_finalized_by_executor = True
 
-            return after_stream(plan, prep, state)
+            return await loop.run_in_executor(
+                None,
+                functools.partial(after_stream, plan, prep, state),
+            )
     except TransportConnectionError as ce:
         raise PartialHaulError("connection error") from ce
     except TransportError as te:

--- a/src/pyhaul/async_engine.py
+++ b/src/pyhaul/async_engine.py
@@ -25,6 +25,7 @@ import inspect
 import logging
 import os
 from collections.abc import Mapping
+from http import HTTPStatus
 from pathlib import Path
 
 from pyhaul._engine_common import (
@@ -50,9 +51,6 @@ from pyhaul.transport.errors import TransportConnectionError, TransportError
 from pyhaul.transport.protocols import AsyncTransportSession
 
 logger = logging.getLogger(__name__)
-
-# HTTP 416 Range Not Satisfiable — must match ``_engine_common._HTTP_416``.
-_HTTP_RANGE_NOT_SATISFIABLE = 416
 
 
 def _sync_flush(fd: int, plan: StreamPlan, prep: PrepareHaul) -> None:
@@ -156,7 +154,7 @@ async def haul_async(  # noqa: C901, PLR0912, PLR0915 — stream loop + transpor
     try:
         async with transport.stream_get(prep.parsed_url, headers=final_headers) as resp:
             # 416 → _on_416 may SHA-hash multi-GB .part files before finalize — offload.
-            if resp.status_code == _HTTP_RANGE_NOT_SATISFIABLE:
+            if resp.status_code == HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE:
                 action = await loop.run_in_executor(
                     None,
                     functools.partial(

--- a/src/pyhaul/async_probe.py
+++ b/src/pyhaul/async_probe.py
@@ -1,0 +1,28 @@
+"""Async remote metadata probe."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from pyhaul._probe_common import run_probe_async
+from pyhaul._session_dispatch import coerce_async_session
+from pyhaul._types import ProbeResult
+from pyhaul.transport.types import TransportRequestOptions
+
+
+async def probe_async(
+    url: str,
+    client: object,
+    *,
+    headers: Mapping[str, str] | None = None,
+    options: TransportRequestOptions | None = None,
+) -> ProbeResult:
+    """Async version of :func:`~pyhaul.probe.probe`.
+
+    *client* is coerced with the same adapter registry as :func:`~pyhaul.async_engine.haul_async`.
+    """
+    transport = coerce_async_session(client)
+    return await run_probe_async(transport, url, headers=headers, options=options)
+
+
+__all__ = ["probe_async"]

--- a/src/pyhaul/checkpoint.py
+++ b/src/pyhaul/checkpoint.py
@@ -15,7 +15,8 @@ from dataclasses import dataclass, field
 from enum import IntEnum, unique
 from typing import Final, Protocol, runtime_checkable
 
-from pyhaul._types import ControlFileError, ETag, parse_etag
+from pyhaul._types import ControlFileError
+from pyhaul.etag import EMPTY_ETAG, ETag
 
 # On-disk / wire version (v1 is the only format today).
 V1_BINARY: Final = 1
@@ -100,7 +101,9 @@ class V1BinaryCodec:
         extensions = bytearray()
 
         if cp.etag:
-            extensions.extend(self._pack_tlv(Tag.ETAG, cp.etag.encode("utf-8")))
+            canon = cp.etag.to_canonical()
+            if canon:
+                extensions.extend(self._pack_tlv(Tag.ETAG, canon.encode("utf-8")))
 
         if cp.reported_length is not None:
             extensions.extend(self._pack_tlv(Tag.REPORTED_LENGTH, struct.pack("<Q", cp.reported_length)))
@@ -168,7 +171,7 @@ class V1BinaryCodec:
         )
 
     def _parse_extensions(self, data: bytes, header_size: int) -> tuple[ETag, int | None, bytes | None]:
-        etag = ETag("")
+        etag = EMPTY_ETAG
         reported_len: int | None = None
         tail_hash: bytes | None = None
 
@@ -195,7 +198,7 @@ class V1BinaryCodec:
             value = data[ptr + 3 : ptr + 3 + v_len]
 
             if tag_val == Tag.ETAG:
-                etag = parse_etag(value.decode("utf-8"))
+                etag = ETag.from_canonical(value.decode("utf-8"))
             elif tag_val == Tag.REPORTED_LENGTH and v_len == _REPORTED_LEN_U64_SIZE:
                 reported_len = struct.unpack("<Q", value)[0]
             elif tag_val == Tag.TAIL_HASH:

--- a/src/pyhaul/etag.py
+++ b/src/pyhaul/etag.py
@@ -1,0 +1,310 @@
+"""HTTP ``entity-tag`` parsing and serialization for pyhaul.
+
+Immutable :class:`EntityTag` values model absent validators, strong / weak tags,
+and the ``*`` wildcard used with ``If-Match`` / ``If-None-Match``.
+
+Absent validators use ``opaque_tag is None`` — distinct from a present strong tag
+whose opaque is the empty string (wire form ``""``).
+
+Equality and hashing intentionally ignore :attr:`~EntityTag.raw_value` — only
+the semantic triple ``(opaque_tag, is_weak, is_wildcard)`` matters — so the same
+logical validator compares equal regardless of quoting quirks in the original
+header bytes.
+
+Checkpoint TLV payloads use :meth:`EntityTag.to_canonical` / :meth:`EntityTag.from_canonical`:
+RFC ``entity-tag`` shaped strings (strong ``"<opaque>"``, weak ``W/"<opaque>"``, or ``*``),
+so delimiters are explicit and every opaque round-trips byte-identically.
+Legacy bare-token blobs (``abc`` / ``W/abc``) still decode via :meth:`from_canonical`.
+
+Unquoted opaques allow non-ASCII Unicode (matching tolerant HTTP header field decoding as in
+libraries like httpx: ascii / utf-8 / latin-1 fallbacks on the wire). Structural characters
+(SP, HTAB, CR, LF, ``"``, ``,``), other ASCII controls (below SP), and DEL are still rejected.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, final
+
+# ─── Module-private grammar helpers (no allocations on hot absent path) ───
+
+_MIN_WHOLE_QUOTED_CHARS = 2  # opening ``"`` + closing ``"`` (fast path: no escapes)
+
+# Unquoted opaque: allow Unicode (obs-text-friendly); still forbid RFC-ish separators and C0 + DEL.
+_UNQUOTED_DISALLOWED_CHARS = frozenset(' \t\r\n",')
+_UNQUOTED_MIN_CODE_POINT = 32  # exclude ASCII controls (SP handled via disallowed set)
+_UNQUOTED_DEL_CODE_POINT = 127
+
+
+def _opaque_ok_unquoted_token(value: str) -> bool:
+    """True if *value* is usable as a legacy bare opaque (no surrounding quotes).
+
+    Allows non-ASCII (consistent with quoted-string results once headers are decoded). Still
+    rejects whitespace / quote / comma and ASCII control characters (C0 + DEL), which cannot
+    appear in a stable bare token.
+    """
+    if not value:
+        return False
+    if any(c in _UNQUOTED_DISALLOWED_CHARS for c in value):
+        return False
+    return all((o := ord(c)) >= _UNQUOTED_MIN_CODE_POINT and o != _UNQUOTED_DEL_CODE_POINT for c in value)
+
+
+def _parse_leading_quoted_opaque_whole(value: str) -> str | None:
+    """Parse ``quoted-string`` consuming *value* entirely (RFC 9110 ``quoted-string``)."""
+    if not value.startswith('"'):
+        return None
+    # Fast path: no backslashes → no quoted-pairs; require exactly two ``"`` so the only
+    # closing quote is the final octet (rejects ``"a"b"`` without falling through).
+    if (
+        len(value) >= _MIN_WHOLE_QUOTED_CHARS
+        and value.endswith('"')
+        and "\\" not in value
+        and value.count('"') == _MIN_WHOLE_QUOTED_CHARS
+    ):
+        return value[1:-1]
+    i = 1
+    chunks: list[str] = []
+    while i < len(value):
+        c = value[i]
+        if c == "\\":
+            if i + 1 >= len(value):
+                return None
+            chunks.append(value[i + 1])
+            i += 2
+        elif c == '"':
+            if i != len(value) - 1:
+                return None
+            return "".join(chunks)
+        else:
+            chunks.append(c)
+            i += 1
+    return None
+
+
+def _split_weak_prefix(value: str) -> tuple[bool, str]:
+    """Strip ``W/`` / ``w/`` and liberal OWS before the tag payload."""
+    if value.casefold().startswith("w/"):
+        return True, value[2:].lstrip()
+    return False, value
+
+
+def _escape_opaque_for_dquotes(opaque: str) -> str:
+    return opaque.replace("\\", "\\\\").replace('"', '\\"')
+
+
+# ─── Public model ───
+
+
+@final
+@dataclass(frozen=True, slots=True, eq=False)
+class EntityTag:
+    """Immutable HTTP entity-tag with explicit weak / wildcard discrimination.
+
+    ``opaque_tag is None`` means absent (no validator). Otherwise ``opaque_tag`` is the
+    opaque string inside the RFC grammar (possibly ``""`` for ``ETag: ""``).
+
+    Use :meth:`parse_header_value` for wire values (``ETag`` response header).
+    Use :meth:`from_canonical` for pyhaul ``.ctrl`` TLV UTF-8 payloads.
+
+    Instances compare equal by ``(opaque_tag, is_weak, is_wildcard)`` only.
+    """
+
+    opaque_tag: str | None
+    is_weak: bool
+    is_wildcard: bool
+    raw_value: str
+
+    def __post_init__(self) -> None:
+        """Validate invariants for wildcard vs absent vs weak-strong tags."""
+        if self.is_wildcard:
+            if self.opaque_tag != "*" or self.is_weak:
+                msg = "wildcard entity-tag requires opaque_tag='*' and is_weak=False"
+                raise ValueError(msg)
+            return
+        if self.opaque_tag is None:
+            if self.is_weak:
+                msg = "absent validator cannot be weak"
+                raise ValueError(msg)
+            return
+        if self.opaque_tag == "" and self.is_weak:
+            msg = "weak validator requires a non-empty opaque_tag"
+            raise ValueError(msg)
+
+    @classmethod
+    def parse_header_value(cls, raw: str) -> EntityTag:  # noqa: PLR0911
+        """Parse an ``ETag`` / ``If-Match`` style field-value fragment.
+
+        Accepts RFC ``quoted-string`` and liberal unquoted tokens. A strong empty
+        quoted opaque (``""``) is valid grammar and preserved on the instance
+        (including :attr:`raw_value`). ``W/""`` yields :data:`EMPTY_ETAG` because weak
+        validators require a non-empty opaque here. Malformed input yields
+        :data:`EMPTY_ETAG`. Whitespace-only → :data:`EMPTY_ETAG`.
+        """
+        stripped = raw.strip()
+        if not stripped:
+            return EMPTY_ETAG
+
+        if stripped == "*":
+            return cls(
+                opaque_tag="*",
+                is_weak=False,
+                is_wildcard=True,
+                raw_value=raw,
+            )
+
+        weak, body = _split_weak_prefix(stripped)
+        if not body:
+            return EMPTY_ETAG
+
+        if body.startswith('"'):
+            opaque = _parse_leading_quoted_opaque_whole(body)
+            if opaque is None:
+                return EMPTY_ETAG
+        elif _opaque_ok_unquoted_token(body):
+            opaque = body
+        else:
+            return EMPTY_ETAG
+
+        if weak and not opaque:
+            return EMPTY_ETAG
+
+        return cls(
+            opaque_tag=opaque,
+            is_weak=weak,
+            is_wildcard=False,
+            raw_value=raw,
+        )
+
+    @classmethod
+    def from_canonical(cls, value: str) -> EntityTag:
+        """Rebuild from UTF-8 stored by :meth:`to_canonical`.
+
+        Expects quoted RFC ``entity-tag`` text for values written by current pyhaul.
+        Leading / trailing ASCII OWS is stripped once (surrounding the whole blob).
+        Legacy control files may hold bare tokens (no quotes); those still parse when
+        they satisfy the same rules as :meth:`parse_header_value`.
+        """
+        stripped = value.strip()
+        if not stripped:
+            return EMPTY_ETAG
+        return cls.parse_header_value(stripped)
+
+    def __bool__(self) -> bool:
+        """True when this tag is present (wildcard or any opaque, including empty)."""
+        return self.is_wildcard or self.opaque_tag is not None
+
+    def __eq__(self, other: object) -> bool:
+        """Equality by semantic triple; :attr:`raw_value` is ignored."""
+        if not isinstance(other, EntityTag):
+            return NotImplemented
+        return (
+            self.opaque_tag == other.opaque_tag
+            and self.is_weak == other.is_weak
+            and self.is_wildcard == other.is_wildcard
+        )
+
+    def __hash__(self) -> int:
+        """Hash matches :meth:`__eq__` (semantic triple only)."""
+        return hash((self.opaque_tag, self.is_weak, self.is_wildcard))
+
+    def __repr__(self) -> str:
+        """Debug representation without :attr:`raw_value` (can be large)."""
+        return (
+            f"{type(self).__name__}(opaque_tag={self.opaque_tag!r}, "
+            f"is_weak={self.is_weak}, is_wildcard={self.is_wildcard})"
+        )
+
+    def __str__(self) -> str:
+        """Canonical HTTP ``entity-tag`` field-value (empty when absent)."""
+        return self.to_http_field_value()
+
+    # --- Semantics (RFC 9110 §8.8.3 strong / weak comparison) ---
+
+    def strong_equals(self, other: object) -> bool:
+        """Strong comparison: both strong validators and opaque_tags byte-equal."""
+        if not isinstance(other, EntityTag):
+            return False
+        if not self or not other:
+            return False
+        if self.is_wildcard or other.is_wildcard:
+            return False
+        if self.is_weak or other.is_weak:
+            return False
+        so, oo = self.opaque_tag, other.opaque_tag
+        if so is None or oo is None:
+            return False
+        return so == oo
+
+    def weak_equals(self, other: object) -> bool:
+        """Weak comparison: opaque_tags equal; weak/strong flags ignored (wildcards excluded)."""
+        if not isinstance(other, EntityTag):
+            return False
+        if not self or not other:
+            return False
+        if self.is_wildcard or other.is_wildcard:
+            return False
+        so, oo = self.opaque_tag, other.opaque_tag
+        if so is None or oo is None:
+            return False
+        return so == oo
+
+    @property
+    def usable_for_byte_range_precondition(self) -> bool:
+        """Strong, non-wildcard tag suitable for ``If-Range`` / strict 206 equality."""
+        return bool(self) and not self.is_weak and not self.is_wildcard
+
+    # --- Serialization ---
+
+    def to_http_field_value(self) -> str:
+        """RFC ``entity-tag`` for outbound headers (``If-Range``, ``If-Match``, …)."""
+        if self.opaque_tag is None:
+            return ""
+        if self.is_wildcard:
+            return "*"
+        esc = _escape_opaque_for_dquotes(self.opaque_tag)
+        if self.is_weak:
+            return f'W/"{esc}"'
+        return f'"{esc}"'
+
+    def to_canonical(self) -> str:
+        r"""RFC-shaped ``entity-tag`` text for ``.part.ctrl`` TLV UTF-8 (or ``""`` when absent).
+
+        Uses the same quoting as :meth:`to_http_field_value` so the opaque is always
+        framed by ``quoted-string`` rules (escaping ``\`` and ``"`` inside the opaque).
+        """
+        return self.to_http_field_value()
+
+
+EMPTY_ETAG: Final[EntityTag] = EntityTag(
+    opaque_tag=None,
+    is_weak=False,
+    is_wildcard=False,
+    raw_value="",
+)
+
+# Historical public name — ``ETag`` was previously a ``typing.NewType`` over ``str``.
+ETag = EntityTag
+
+
+def parse_etag(raw: object) -> EntityTag:
+    """Backward-compatible wrapper around :meth:`EntityTag.parse_header_value`.
+
+    Non-string raises :class:`TypeError`.
+    """
+    if not isinstance(raw, str):
+        raise TypeError(f"etag must be str, got {type(raw).__name__}")
+    return EntityTag.parse_header_value(raw)
+
+
+def format_entity_tag_for_http_header(etag: EntityTag) -> str:
+    """Serialize for merged request headers; absent tags yield ``""``."""
+    return etag.to_http_field_value()
+
+
+def is_weak_validator(etag: EntityTag) -> bool:
+    """True if *etag* is a weak validator (``W/…``).
+
+    Weak validators are not used for byte-range preconditioning in pyhaul.
+    """
+    return bool(etag) and etag.is_weak

--- a/src/pyhaul/probe.py
+++ b/src/pyhaul/probe.py
@@ -1,0 +1,36 @@
+"""Sync remote metadata probe (HEAD + optional ranged GET).
+
+One :func:`probe` call performs at least one HTTP round-trip (``HEAD``), and may add a
+byte-ranged ``GET`` when ``HEAD`` did not expose everything needed for common shard planners.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from pyhaul._probe_common import run_probe_sync
+from pyhaul._session_dispatch import coerce_sync_session
+from pyhaul._types import ProbeResult
+from pyhaul.transport.types import TransportRequestOptions
+
+
+def probe(
+    url: str,
+    client: object,
+    *,
+    headers: Mapping[str, str] | None = None,
+    options: TransportRequestOptions | None = None,
+) -> ProbeResult:
+    """Discover static metadata for *url* using the caller's HTTP session.
+
+    The sequence mirrors pypdl-style probing: send ``HEAD``, then — when metadata is still
+    incomplete — ``GET`` with ``Range: bytes=0-0`` and drain the tiny body.
+
+    *client* is coerced with the same adapter registry as :func:`~pyhaul.engine.haul`.
+    Transport errors from the underlying HTTP library propagate unwrapped.
+    """
+    transport = coerce_sync_session(client)
+    return run_probe_sync(transport, url, headers=headers, options=options)
+
+
+__all__ = ["probe"]

--- a/src/pyhaul/transport/_headers.py
+++ b/src/pyhaul/transport/_headers.py
@@ -50,7 +50,9 @@ class TransportHeaders(Mapping[str, str]):
     Field names are matched case-insensitively per HTTP semantics.
     Duplicate names are preserved in wire order.
 
-    Construct via `build`, `from_pairs`, or `from_mapping`.
+    Constructor arguments are normalized (names lowercased/stripped, values
+    stripped) — same rules as :meth:`from_pairs`. Prefer :meth:`build`,
+    :meth:`from_pairs`, or :meth:`from_mapping` for readability.
     """
 
     __slots__ = ("_hash", "_index", "_items")
@@ -58,11 +60,12 @@ class TransportHeaders(Mapping[str, str]):
     _index: dict[str, tuple[int, ...]]
     _hash: int | None
 
-    def __init__(self, items: Pairs = (), /) -> None:
+    def __init__(self, items: Iterable[Pair] = (), /) -> None:
+        norm_items: Pairs = tuple((_norm_name(k), _norm_value(v)) for k, v in items)
         index: dict[str, list[int]] = {}
-        for i, (k, _) in enumerate(items):
+        for i, (k, _) in enumerate(norm_items):
             index.setdefault(k, []).append(i)
-        object.__setattr__(self, "_items", items)
+        object.__setattr__(self, "_items", norm_items)
         object.__setattr__(self, "_index", {k: tuple(v) for k, v in index.items()})
         object.__setattr__(self, "_hash", None)
 
@@ -111,8 +114,9 @@ class TransportHeaders(Mapping[str, str]):
         """Build from an ordered ``(name, value)`` iterable.
 
         Preserves duplicate names and wire order for `get_all`.
+        Normalization matches direct :class:`TransportHeaders` construction.
         """
-        return cls(tuple((_norm_name(n), _norm_value(v)) for n, v in pairs))
+        return cls(tuple(pairs))
 
     @classmethod
     def from_mapping(cls, mapping: Mapping[str, str]) -> Self:
@@ -192,6 +196,11 @@ class TransportHeaders(Mapping[str, str]):
             return self._items == other._items
         if isinstance(other, Mapping):
             m = cast("Mapping[str, str]", other)
+            # ``dict(Mapping.items())`` keeps only one value per key; ``self.items()``
+            # only exposes the first value per normalized name. Never treat as equal
+            # when this header bag carries multiple wire rows for the same field name.
+            if len(self._items) != len(self._index):
+                return False
             return dict(self.items()) == dict(m.items())
         return NotImplemented
 
@@ -259,12 +268,17 @@ class TransportHeaders(Mapping[str, str]):
         return self.without(name).with_added(name, value)
 
     # ------------------------------------------------------------------
-    # Repr — redacts sensitive headers
+    # Repr — ``[(name, value), ...]`` wire shape (not a dict literal); redacts sensitive
     # ------------------------------------------------------------------
 
     def __repr__(self) -> str:
-        body = ", ".join(f"{k!r}: {'[redacted]' if k in _SENSITIVE else v!r}" for k, v in self._items)
-        return f"{type(self).__name__}({{{body}}})"
+        chunks: list[str] = []
+        for k, v in self._items:
+            if k in _SENSITIVE:
+                chunks.append(f"({k!r}, '[redacted]')")
+            else:
+                chunks.append(f"({k!r}, {v!r})")
+        return f"{type(self).__name__}([{', '.join(chunks)}])"
 
     # ------------------------------------------------------------------
     # Safe dict for structured logging
@@ -284,8 +298,14 @@ class TransportHeaders(Mapping[str, str]):
     # ------------------------------------------------------------------
 
     def to_wire(self) -> bytes:
-        r"""Serialize to ``b'name: value\r\n...'`` form."""
-        return b"".join(f"{k}: {v}\r\n".encode("latin-1") for k, v in self._items)
+        r"""Serialize to ``b'name: value\r\n...'`` form.
+
+        Uses UTF-8 for the combined header lines. HTTP/1 historically treated
+        field values as ISO-8859-1 octets; UTF-8 is common for Unicode today,
+        and matches how aiohttp serializes outgoing prelude lines and how httpx
+        defaults header encoding when emitting bytes from ``str`` values.
+        """
+        return b"".join(f"{k}: {v}\r\n".encode() for k, v in self._items)
 
     __match_args__ = ("raw_items",)
 

--- a/src/pyhaul/transport/aiohttp_adapter.py
+++ b/src/pyhaul/transport/aiohttp_adapter.py
@@ -174,6 +174,27 @@ class AsyncAiohttpAdapter:
         ):
             yield AiohttpTransportResponse(resp)
 
+    @asynccontextmanager
+    async def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AsyncIterator[AsyncTransportResponse]:
+        """Open a HEAD request and yield the response."""
+        kwargs = _request_options_to_aiohttp_kwargs(options)
+        async with (
+            map_aiohttp_transport_errors_async(),
+            self._session.head(
+                str(url),
+                headers=dict(headers),
+                raise_for_status=False,
+                **kwargs,
+            ) as resp,
+        ):
+            yield AiohttpTransportResponse(resp)
+
 
 def async_aiohttp_transport(session: aiohttp.ClientSession) -> AsyncTransportSession:
     """Shorthand: ``AsyncAiohttpAdapter(session)``."""

--- a/src/pyhaul/transport/httpx_adapter.py
+++ b/src/pyhaul/transport/httpx_adapter.py
@@ -147,6 +147,22 @@ class HttpxAdapter:
         ):
             yield HttpxTransportResponse(resp)
 
+    @contextmanager
+    def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> Iterator[TransportResponse]:
+        """Open a HEAD request and yield the response."""
+        kwargs = _request_options_to_httpx_kwargs(options)
+        with (
+            map_httpx_transport_errors(),
+            self._client.stream("HEAD", str(url), headers=dict(headers), **kwargs) as resp,
+        ):
+            yield HttpxTransportResponse(resp)
+
 
 def httpx_transport(client: httpx.Client) -> TransportSession:
     """Shorthand: ``HttpxAdapter(client)``."""
@@ -215,6 +231,20 @@ class AsyncHttpxAdapter:
         kwargs = _request_options_to_httpx_kwargs(options)
         with map_httpx_transport_errors():
             async with self._client.stream("GET", str(url), headers=dict(headers), **kwargs) as resp:
+                yield AsyncHttpxTransportResponse(resp)
+
+    @asynccontextmanager
+    async def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AsyncIterator[AsyncTransportResponse]:
+        """Open a HEAD request and yield the response."""
+        kwargs = _request_options_to_httpx_kwargs(options)
+        with map_httpx_transport_errors():
+            async with self._client.stream("HEAD", str(url), headers=dict(headers), **kwargs) as resp:
                 yield AsyncHttpxTransportResponse(resp)
 
 

--- a/src/pyhaul/transport/niquests_adapter.py
+++ b/src/pyhaul/transport/niquests_adapter.py
@@ -102,6 +102,23 @@ class NiquestsAdapter:
         ):
             yield NiquestsTransportResponse(resp)
 
+    @contextmanager
+    def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> Iterator[TransportResponse]:
+        """Open a HEAD request and yield the response."""
+        kwargs = request_options_to_requests_like_kwargs(options)
+        with map_requests_like_transport_errors(_niquests_exceptions):
+            resp = self._session.head(url, headers=dict(headers), **kwargs)
+        try:
+            yield NiquestsTransportResponse(resp)
+        finally:
+            resp.close()
+
 
 def niquests_transport(session: niquests.Session) -> TransportSession:
     """Shorthand: ``NiquestsAdapter(session)``."""
@@ -146,6 +163,38 @@ class AsyncNiquestsTransportResponse(AsyncTransportResponse):
                 yield chunk
 
 
+class AsyncNiquestsHeadTransportResponse(AsyncTransportResponse):
+    """HEAD via :class:`niquests.AsyncSession` returns a sync :class:`~niquests.Response`."""
+
+    __slots__ = ("_headers", "_resp")
+
+    def __init__(self, resp: niquests.Response) -> None:
+        self._resp = resp
+        self._headers: TransportHeaders | None = None
+
+    @property
+    def status_code(self) -> int:
+        """HTTP status code of the response."""
+        return cast("int", self._resp.status_code)
+
+    @property
+    def headers(self) -> TransportHeaders:
+        """Response headers, lazily parsed on first access."""
+        if self._headers is None:
+            self._headers = headers_from_niquests_response(self._resp)
+        return self._headers
+
+    def raise_for_status(self) -> None:
+        """Raise :exc:`~pyhaul.transport.errors.TransportHTTPError` for 4xx/5xx responses."""
+        with map_requests_like_transport_errors(_niquests_exceptions):
+            self._resp.raise_for_status()
+
+    async def aiter_raw_bytes(self, *, chunk_size: int) -> AsyncIterator[bytes]:
+        """HEAD responses carry no entity body; emit one empty chunk for API symmetry."""
+        del chunk_size
+        yield b""
+
+
 class AsyncNiquestsAdapter:
     """Wrap a :class:`niquests.AsyncSession` as an :class:`AsyncTransportSession`."""
 
@@ -174,6 +223,23 @@ class AsyncNiquestsAdapter:
                 yield AsyncNiquestsTransportResponse(resp)
             finally:
                 await resp.close()
+
+    @asynccontextmanager
+    async def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AsyncIterator[AsyncTransportResponse]:
+        """Open a HEAD request and yield the response."""
+        kwargs = request_options_to_requests_like_kwargs(options)
+        with map_requests_like_transport_errors(_niquests_exceptions):
+            resp = await self._session.head(url, headers=dict(headers), **kwargs)
+        try:
+            yield AsyncNiquestsHeadTransportResponse(resp)
+        finally:
+            resp.close()
 
 
 def async_niquests_transport(session: niquests.AsyncSession) -> AsyncTransportSession:

--- a/src/pyhaul/transport/protocols.py
+++ b/src/pyhaul/transport/protocols.py
@@ -51,7 +51,7 @@ class TransportResponse(Protocol):
 
 @runtime_checkable
 class TransportSession(Protocol):
-    """Sync transport: ``prepare_headers`` then ``stream_get``; no lifecycle ownership."""
+    """Sync transport: ``prepare_headers``, ``stream_get``, and ``stream_head``."""
 
     def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
         """Optionally mutate headers before they are sent.
@@ -75,6 +75,16 @@ class TransportSession(Protocol):
         options: TransportRequestOptions | None = None,
     ) -> AbstractContextManager[TransportResponse]:
         """Context manager yielding a response whose body must be streamed."""
+        ...
+
+    def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AbstractContextManager[TransportResponse]:
+        """Context manager yielding a HEAD response (entity body must not be read)."""
         ...
 
     # CPD-ON
@@ -113,7 +123,7 @@ class AsyncTransportResponse(Protocol):
 
 @runtime_checkable
 class AsyncTransportSession(Protocol):
-    """Async transport: ``prepare_headers`` then ``stream_get`` (async context manager)."""
+    """Async transport: ``prepare_headers``, ``stream_get``, and ``stream_head``."""
 
     def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
         """Optionally mutate headers before they are sent (see sync version)."""
@@ -128,6 +138,16 @@ class AsyncTransportSession(Protocol):
         options: TransportRequestOptions | None = None,
     ) -> AbstractAsyncContextManager[AsyncTransportResponse]:
         """Async context manager yielding a response whose body must be streamed."""
+        ...
+
+    def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AbstractAsyncContextManager[AsyncTransportResponse]:
+        """Async context manager yielding a HEAD response."""
         ...
 
     # CPD-ON

--- a/src/pyhaul/transport/proxy_transport_session.py
+++ b/src/pyhaul/transport/proxy_transport_session.py
@@ -113,7 +113,7 @@ class AsyncTransportSessionProxyRecipe:
 
 @final
 class _ProxiedTransportSession:
-    """Delegates ``stream_get`` faithfully; optionally layers ``prepare_headers`` after inner."""
+    """Delegates ``stream_get`` / ``stream_head``; optionally layers ``prepare_headers`` after inner."""
 
     __slots__ = ("_inner", "_outer_prepare_headers")
 
@@ -139,6 +139,15 @@ class _ProxiedTransportSession:
         options: TransportRequestOptions | None = None,
     ) -> AbstractContextManager[TransportResponse]:
         return self._inner.stream_get(url, headers=headers, options=options)
+
+    def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AbstractContextManager[TransportResponse]:
+        return self._inner.stream_head(url, headers=headers, options=options)
 
 
 @final
@@ -168,6 +177,17 @@ class _ProxiedAsyncTransportSession:
         options: TransportRequestOptions | None = None,
     ) -> AsyncIterator[AsyncTransportResponse]:
         async with self._inner.stream_get(url, headers=headers, options=options) as resp:
+            yield resp
+
+    @asynccontextmanager
+    async def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AsyncIterator[AsyncTransportResponse]:
+        async with self._inner.stream_head(url, headers=headers, options=options) as resp:
             yield resp
 
 

--- a/src/pyhaul/transport/requests_adapter.py
+++ b/src/pyhaul/transport/requests_adapter.py
@@ -86,6 +86,23 @@ class RequestsAdapter:
         ):
             yield RequestsTransportResponse(resp)
 
+    @contextmanager
+    def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> Iterator[TransportResponse]:
+        """Open a HEAD request and yield the response."""
+        kwargs = request_options_to_requests_like_kwargs(options)
+        with map_requests_like_transport_errors(_requests_exceptions):
+            resp = self._session.head(str(url), headers=dict(headers), **kwargs)
+        try:
+            yield RequestsTransportResponse(resp)
+        finally:
+            resp.close()
+
 
 def requests_transport(session: requests.Session) -> TransportSession:
     """Shorthand: ``RequestsAdapter(session)``."""

--- a/src/pyhaul/transport/urllib3_adapter.py
+++ b/src/pyhaul/transport/urllib3_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
+from http import HTTPStatus
 from typing import TypedDict
 
 import urllib3
@@ -19,8 +20,6 @@ from pyhaul.transport.errors import (
 )
 from pyhaul.transport.protocols import TransportResponse, TransportSession
 from pyhaul.transport.types import TransportHeaders, TransportRequestOptions
-
-_HTTP_400 = 400
 
 
 def headers_from_urllib3_response(resp: urllib3.HTTPResponse) -> TransportHeaders:
@@ -100,7 +99,7 @@ class Urllib3TransportResponse(TransportResponse):
 
     def raise_for_status(self) -> None:
         """Raise :exc:`~pyhaul.transport.errors.TransportHTTPError` for 4xx/5xx responses."""
-        if self._resp.status >= _HTTP_400:
+        if self._resp.status >= HTTPStatus.BAD_REQUEST:
             raise TransportHTTPError(
                 f"HTTP {self._resp.status}",
                 status_code=self._resp.status,

--- a/src/pyhaul/transport/urllib3_adapter.py
+++ b/src/pyhaul/transport/urllib3_adapter.py
@@ -154,6 +154,30 @@ class Urllib3Adapter:
             transport_resp.close()
             resp.release_conn()
 
+    @contextmanager
+    def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> Iterator[TransportResponse]:
+        """Open a HEAD request and yield the response."""
+        kw = _build_urlopen_kwargs(options)
+        with map_urllib3_transport_errors():
+            resp = self._pool.request(
+                "HEAD",
+                str(url),
+                headers=dict(headers),
+                **kw,
+            )
+        transport_resp = Urllib3TransportResponse(resp)
+        try:
+            yield transport_resp
+        finally:
+            transport_resp.close()
+            resp.release_conn()
+
 
 def urllib3_transport(pool: urllib3.PoolManager) -> TransportSession:
     """Shorthand: ``Urllib3Adapter(pool)``."""

--- a/tests/redirect_support.py
+++ b/tests/redirect_support.py
@@ -155,6 +155,19 @@ class PinnedRedirectSyncTransport:
         with self._inner.stream_get(url, headers=headers, options=merged) as resp:
             yield resp
 
+    @contextmanager
+    def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> Iterator[TransportResponse]:
+        """Pin redirect policy, then open HEAD."""
+        merged = merge_allow_redirects(options, pin=self._allow_redirects)
+        with self._inner.stream_head(url, headers=headers, options=merged) as resp:
+            yield resp
+
 
 class PinnedRedirectAsyncTransport:
     """Wraps an async adapter and merges ``TransportRequestOptions(allow_redirects=...)``."""
@@ -182,6 +195,23 @@ class PinnedRedirectAsyncTransport:
         @asynccontextmanager
         async def _cm() -> AsyncIterator[AsyncTransportResponse]:
             async with self._inner.stream_get(url, headers=headers, options=merged) as resp:
+                yield resp
+
+        return _cm()
+
+    def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AbstractAsyncContextManager[AsyncTransportResponse]:
+        """Pin redirect policy, then open HEAD."""
+        merged = merge_allow_redirects(options, pin=self._allow_redirects)
+
+        @asynccontextmanager
+        async def _cm() -> AsyncIterator[AsyncTransportResponse]:
+            async with self._inner.stream_head(url, headers=headers, options=merged) as resp:
                 yield resp
 
         return _cm()

--- a/tests/test_async_engine.py
+++ b/tests/test_async_engine.py
@@ -85,6 +85,17 @@ class AsyncMockSession:
             raise RuntimeError(msg)
         yield self.responses[idx]
 
+    @asynccontextmanager
+    async def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AsyncIterator[AsyncTransportResponse]:
+        raise RuntimeError("AsyncMockSession.stream_head is not used by haul_async tests")
+        yield self.responses[0]
+
 
 def _make_206(body: bytes, start: int, total: int | None, etag: str = '"test"') -> AsyncMockResponse:
     end = start + len(body) - 1

--- a/tests/test_async_engine.py
+++ b/tests/test_async_engine.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
 
-from pyhaul._types import CompleteHaul, ETag, HaulState, Url
+from pyhaul._types import CompleteHaul, ETag, HaulState, ServerMisconfiguredError, Url
 from pyhaul.checkpoint import LATEST_VERSION, Checkpoint, registry
 from pyhaul.persist import ctrl_path_for, write_atomic
 from pyhaul.transport.protocols import AsyncTransportResponse
@@ -167,6 +168,33 @@ class TestAsyncFresh206KnownTotal:
         assert state.reported_length == len(body)
 
     @pytest.mark.anyio
+    async def test_on_progress_async_callback(self, tmp_path: Path) -> None:
+        from pyhaul.async_engine import haul_async
+
+        body = b"Hello, async world!"
+        session = AsyncMockSession()
+        session.add_response(_make_206(body, start=0, total=len(body)))
+
+        dest = tmp_path / "out.bin"
+        state = HaulState()
+        seen: list[int] = []
+
+        async def on_progress(s: HaulState) -> None:
+            await asyncio.sleep(0)
+            seen.append(s.valid_length)
+
+        await haul_async(
+            _TEST_URL,
+            session,
+            dest=str(dest),
+            state=state,
+            chunk_size=4,
+            on_progress=on_progress,
+        )
+        assert len(seen) >= 2
+        assert seen[-1] == len(body)
+
+    @pytest.mark.anyio
     async def test_sends_range_header(self, tmp_path: Path) -> None:
         from pyhaul.async_engine import haul_async
 
@@ -241,7 +269,7 @@ class TestAsyncResume206:
                     start=0,
                     extent=10,
                     valid_length=5,
-                    etag=ETag('"test"'),
+                    etag=ETag.from_canonical("test"),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=10,
@@ -261,6 +289,76 @@ class TestAsyncResume206:
         assert isinstance(req_headers, TransportHeaders)
         assert req_headers["Range"] == "bytes=5-"
         assert req_headers["If-Range"] == '"test"'
+
+    @pytest.mark.anyio
+    async def test_mislabeled_206_full_body_restores_like_graceful_200(self, tmp_path: Path) -> None:
+        from pyhaul.async_engine import haul_async
+
+        full_body = b"AAAAABBBBB"
+        first_half = full_body[:5]
+
+        dest = tmp_path / "out.bin"
+        part_path = dest.with_suffix(dest.suffix + ".part")
+        ctrl_path = ctrl_path_for(part_path)
+
+        part_path.write_bytes(first_half)
+        write_atomic(
+            ctrl_path,
+            registry.dump(
+                Checkpoint(
+                    version=LATEST_VERSION,
+                    start=0,
+                    extent=10,
+                    valid_length=5,
+                    etag=ETag.from_canonical("test"),
+                    block_size=8 * 1024 * 1024,
+                    hashes=[],
+                    reported_length=10,
+                )
+            ),
+        )
+
+        session = AsyncMockSession()
+        session.add_response(_make_206(full_body, start=0, total=len(full_body)))
+
+        result = await haul_async(_TEST_URL, session, dest=str(dest))
+
+        assert isinstance(result, CompleteHaul)
+        assert dest.read_bytes() == full_body
+
+    @pytest.mark.anyio
+    async def test_206_partial_from_zero_when_resume_still_misconfigured(self, tmp_path: Path) -> None:
+        from pyhaul.async_engine import haul_async
+
+        full_body = b"AAAAABBBBB"
+        first_half = full_body[:5]
+
+        dest = tmp_path / "out.bin"
+        part_path = dest.with_suffix(dest.suffix + ".part")
+        ctrl_path = ctrl_path_for(part_path)
+
+        part_path.write_bytes(first_half)
+        write_atomic(
+            ctrl_path,
+            registry.dump(
+                Checkpoint(
+                    version=LATEST_VERSION,
+                    start=0,
+                    extent=10,
+                    valid_length=5,
+                    etag=ETag.from_canonical("test"),
+                    block_size=8 * 1024 * 1024,
+                    hashes=[],
+                    reported_length=10,
+                )
+            ),
+        )
+
+        session = AsyncMockSession()
+        session.add_response(_make_206(full_body[:5], start=0, total=len(full_body)))
+
+        with pytest.raises(ServerMisconfiguredError, match=r"Content-Range start 0 != requested 5"):
+            await haul_async(_TEST_URL, session, dest=str(dest))
 
 
 class TestAsyncResumeEtagChanged:
@@ -284,7 +382,7 @@ class TestAsyncResumeEtagChanged:
                     start=0,
                     extent=5,
                     valid_length=5,
-                    etag=ETag('"old-etag"'),
+                    etag=ETag.from_canonical("old-etag"),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=5,
@@ -320,7 +418,7 @@ class TestAsyncResume416AlreadyComplete:
                     start=0,
                     extent=len(body),
                     valid_length=len(body),
-                    etag=ETag('"test"'),
+                    etag=ETag.from_canonical("test"),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=len(body),
@@ -366,7 +464,7 @@ class TestAsyncCrashRecovery:
                     start=0,
                     extent=len(full_body),
                     valid_length=len(valid_data),
-                    etag=ETag('"test"'),
+                    etag=ETag.from_canonical("test"),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=len(full_body),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,7 +34,9 @@ from pyhaul.transport._headers import TransportHeaders
 
 
 def _make_complete_haul() -> CompleteHaul:
-    return CompleteHaul(elapsed=1.0, sha256="a" * 64, etag=ETag('"test"'), content_type="application/octet-stream")
+    return CompleteHaul(
+        elapsed=1.0, sha256="a" * 64, etag=ETag.from_canonical("test"), content_type="application/octet-stream"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -87,6 +87,16 @@ class MockSession:
             raise RuntimeError(msg)
         yield self.responses[idx]
 
+    @contextmanager
+    def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> Iterator[TransportResponse]:
+        raise RuntimeError("MockSession.stream_head is not used by haul tests")
+
 
 def _make_206_response(body: bytes, start: int, total: int | None, etag: str = '"test"') -> MockResponse:
     end = start + len(body) - 1

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
@@ -10,7 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pyhaul._types import CompleteHaul, ETag, HaulState, PartialHaulError, Url
+from pyhaul._types import EMPTY_ETAG, CompleteHaul, ETag, HaulState, PartialHaulError, ServerMisconfiguredError, Url
 from pyhaul.checkpoint import LATEST_VERSION, Checkpoint, registry
 from pyhaul.persist import ctrl_path_for, write_atomic
 from pyhaul.transport.protocols import TransportResponse
@@ -238,7 +239,7 @@ class TestResume206:
                     start=0,
                     extent=10,
                     valid_length=5,
-                    etag=ETag('"test"'),
+                    etag=ETag.from_canonical("test"),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=10,
@@ -258,6 +259,76 @@ class TestResume206:
         assert isinstance(req_headers, TransportHeaders)
         assert req_headers["Range"] == "bytes=5-"
         assert req_headers["If-Range"] == '"test"'
+
+    def test_mislabeled_206_full_body_restores_like_graceful_200(self, tmp_path: Path) -> None:
+        """206 + Content-Range from byte 0 for entire resource while we resumed."""
+        from pyhaul.engine import haul
+
+        full_body = b"AAAAABBBBB"
+        first_half = full_body[:5]
+
+        dest = tmp_path / "out.bin"
+        part_path = dest.with_suffix(dest.suffix + ".part")
+        ctrl_path = ctrl_path_for(part_path)
+
+        part_path.write_bytes(first_half)
+        write_atomic(
+            ctrl_path,
+            registry.dump(
+                Checkpoint(
+                    version=LATEST_VERSION,
+                    start=0,
+                    extent=10,
+                    valid_length=5,
+                    etag=ETag.from_canonical("test"),
+                    block_size=8 * 1024 * 1024,
+                    hashes=[],
+                    reported_length=10,
+                )
+            ),
+        )
+
+        session = MockSession()
+        session.add_response(_make_206_response(full_body, start=0, total=len(full_body)))
+
+        result = haul(_TEST_URL, session, dest=str(dest))
+
+        assert isinstance(result, CompleteHaul)
+        assert dest.read_bytes() == full_body
+
+    def test_206_partial_from_zero_when_resume_still_misconfigured(self, tmp_path: Path) -> None:
+        """206 bytes 0-4/10 does not cover full instance — do not treat like 200."""
+        from pyhaul.engine import haul
+
+        full_body = b"AAAAABBBBB"
+        first_half = full_body[:5]
+
+        dest = tmp_path / "out.bin"
+        part_path = dest.with_suffix(dest.suffix + ".part")
+        ctrl_path = ctrl_path_for(part_path)
+
+        part_path.write_bytes(first_half)
+        write_atomic(
+            ctrl_path,
+            registry.dump(
+                Checkpoint(
+                    version=LATEST_VERSION,
+                    start=0,
+                    extent=10,
+                    valid_length=5,
+                    etag=ETag.from_canonical("test"),
+                    block_size=8 * 1024 * 1024,
+                    hashes=[],
+                    reported_length=10,
+                )
+            ),
+        )
+
+        session = MockSession()
+        session.add_response(_make_206_response(full_body[:5], start=0, total=len(full_body)))
+
+        with pytest.raises(ServerMisconfiguredError, match=r"Content-Range start 0 != requested 5"):
+            haul(_TEST_URL, session, dest=str(dest))
 
 
 class TestResumeEtagChanged:
@@ -280,7 +351,7 @@ class TestResumeEtagChanged:
                     start=0,
                     extent=5,
                     valid_length=5,
-                    etag=ETag('"old-etag"'),
+                    etag=ETag.from_canonical("old-etag"),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=5,
@@ -319,7 +390,7 @@ class TestResumeEtagChanged:
                     start=0,
                     extent=10,
                     valid_length=5,
-                    etag=ETag('"old"'),
+                    etag=ETag.from_canonical("old"),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=10,
@@ -357,7 +428,7 @@ class TestResume416AlreadyComplete:
                     start=0,
                     extent=len(body),
                     valid_length=len(body),
-                    etag=ETag('"test"'),
+                    etag=ETag.from_canonical("test"),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=len(body),
@@ -401,7 +472,7 @@ class TestResumeNoEtag:
                     start=0,
                     extent=10,
                     valid_length=3,
-                    etag=ETag(""),
+                    etag=EMPTY_ETAG,
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=10,
@@ -423,6 +494,92 @@ class TestResumeNoEtag:
         assert "If-Range" not in req_headers
 
 
+class TestResumeWeakEtag:
+    def test_omits_if_range_and_logs_warning(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """Weak checkpoint ETag: Range only; warning explains missing If-Range precondition."""
+        from pyhaul.engine import haul
+
+        caplog.set_level(logging.WARNING)
+
+        full_body = b"0123456789"
+        first = full_body[:3]
+        rest = full_body[3:]
+
+        dest = tmp_path / "out.bin"
+        part_path = dest.with_suffix(dest.suffix + ".part")
+        ctrl_path = ctrl_path_for(part_path)
+
+        part_path.write_bytes(first)
+        write_atomic(
+            ctrl_path,
+            registry.dump(
+                Checkpoint(
+                    version=LATEST_VERSION,
+                    start=0,
+                    extent=10,
+                    valid_length=3,
+                    etag=ETag.from_canonical("W/weak-token"),
+                    block_size=8 * 1024 * 1024,
+                    hashes=[],
+                    reported_length=10,
+                )
+            ),
+        )
+
+        session = MockSession()
+        session.add_response(_make_206_response(rest, start=3, total=10))
+
+        result = haul(_TEST_URL, session, dest=str(dest))
+
+        assert isinstance(result, CompleteHaul)
+        assert dest.read_bytes() == full_body
+
+        req_headers = session.requests[0]["headers"]
+        assert isinstance(req_headers, TransportHeaders)
+        assert req_headers["Range"] == "bytes=3-"
+        assert "If-Range" not in req_headers
+        assert any("weak ETag" in rec.message for rec in caplog.records)
+
+    def test_206_skips_strict_etag_match_when_checkpoint_weak(self, tmp_path: Path) -> None:
+        """Weak stored validator must not raise ServerMisconfiguredError on ETag drift."""
+        from pyhaul.engine import haul
+
+        full_body = b"AAAAABBBBB"
+        first_half = full_body[:5]
+        second_half = full_body[5:]
+
+        dest = tmp_path / "out.bin"
+        part_path = dest.with_suffix(dest.suffix + ".part")
+        ctrl_path = ctrl_path_for(part_path)
+
+        part_path.write_bytes(first_half)
+        write_atomic(
+            ctrl_path,
+            registry.dump(
+                Checkpoint(
+                    version=LATEST_VERSION,
+                    start=0,
+                    extent=10,
+                    valid_length=5,
+                    etag=ETag.from_canonical("W/orig"),
+                    block_size=8 * 1024 * 1024,
+                    hashes=[],
+                    reported_length=10,
+                )
+            ),
+        )
+
+        session = MockSession()
+        session.add_response(
+            _make_206_response(second_half, start=5, total=10, etag='"different-strong"'),
+        )
+
+        result = haul(_TEST_URL, session, dest=str(dest))
+
+        assert isinstance(result, CompleteHaul)
+        assert dest.read_bytes() == full_body
+
+
 class TestResume416ResourceShrank:
     def test_416_resource_shrank(self, tmp_path: Path) -> None:
         """416 with instance_length < valid_length resets the checkpoint."""
@@ -441,7 +598,7 @@ class TestResume416ResourceShrank:
                     start=0,
                     extent=10,
                     valid_length=10,
-                    etag=ETag('"test"'),
+                    etag=ETag.from_canonical("test"),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=10,
@@ -482,7 +639,7 @@ class TestRestart200SizeChange:
                     start=0,
                     extent=5,
                     valid_length=5,
-                    etag=ETag('"old"'),
+                    etag=ETag.from_canonical("old"),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=5,
@@ -517,7 +674,7 @@ class TestRestart200SizeChange:
                     start=0,
                     extent=12,
                     valid_length=12,
-                    etag=ETag('"old"'),
+                    etag=ETag.from_canonical("old"),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=12,
@@ -552,7 +709,7 @@ class TestRestart200SizeChange:
                     start=0,
                     extent=20,
                     valid_length=20,
-                    etag=ETag('"old"'),
+                    etag=ETag.from_canonical("old"),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=20,
@@ -593,7 +750,7 @@ class TestCrashRecovery:
                     start=0,
                     extent=len(full_body),
                     valid_length=len(valid_data),
-                    etag=ETag('"test"'),
+                    etag=ETag.from_canonical("test"),
                     block_size=8 * 1024 * 1024,
                     hashes=[],
                     reported_length=len(full_body),

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -1,0 +1,387 @@
+"""Unit tests for :mod:`pyhaul.etag` — parsing, serialization, semantics.
+
+No HTTP clients or mock transports; pure string ↔ :class:`~pyhaul.etag.EntityTag` logic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import pyhaul.etag as etag_module
+from pyhaul import (
+    EMPTY_ETAG,
+    EntityTag,
+    ETag,
+    format_entity_tag_for_http_header,
+    is_weak_validator,
+    parse_etag,
+    parse_url,
+)
+from pyhaul.etag import parse_etag as parse_etag_direct
+
+# ─── Module helpers & strict construction ───────────────────────────
+
+
+def test_entity_tag_post_init_rejects_invalid_wildcard_opaque() -> None:
+    with pytest.raises(ValueError, match="wildcard"):
+        EntityTag(opaque_tag="nope", is_weak=False, is_wildcard=True, raw_value="")
+
+
+def test_entity_tag_post_init_rejects_weak_wildcard() -> None:
+    with pytest.raises(ValueError, match="wildcard"):
+        EntityTag(opaque_tag="*", is_weak=True, is_wildcard=True, raw_value="")
+
+
+def test_entity_tag_post_init_rejects_weak_without_opaque() -> None:
+    with pytest.raises(ValueError, match="non-empty opaque"):
+        EntityTag(opaque_tag="", is_weak=True, is_wildcard=False, raw_value="")
+
+
+def test_entity_tag_post_init_rejects_weak_when_absent() -> None:
+    with pytest.raises(ValueError, match="absent validator cannot be weak"):
+        EntityTag(opaque_tag=None, is_weak=True, is_wildcard=False, raw_value="")
+
+
+# ─── parse_etag wrapper ─────────────────────────────────────────────
+
+
+def test_parse_etag_delegates_to_parse_header_value() -> None:
+    assert parse_etag('"x"') == EntityTag.parse_header_value('"x"')
+
+
+def test_parse_etag_type_error_on_non_string() -> None:
+    with pytest.raises(TypeError, match="etag must be str"):
+        parse_etag(None)
+    with pytest.raises(TypeError, match="etag must be str"):
+        parse_etag(b'"bytes"')
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "\t"])
+def test_parse_etag_empty_returns_empty_sentinel(raw: str) -> None:
+    result = parse_etag(raw)
+    assert result is EMPTY_ETAG
+    assert result == EMPTY_ETAG
+    assert not result
+
+
+def test_parse_etag_normalizes_quoted_and_weak() -> None:
+    assert parse_etag('"abc123"') == ETag.from_canonical('"abc123"')
+    assert parse_etag('"abc123"') == ETag.from_canonical("abc123")
+    assert parse_etag('W/"weak-hash"') == ETag.from_canonical('W/"weak-hash"')
+    assert parse_etag('W/"weak-hash"') == ETag.from_canonical("W/weak-hash")
+
+
+def test_parse_etag_strips_whitespace_outside_quotes_only() -> None:
+    assert parse_etag('  "abc"  ') == ETag.from_canonical('"abc"')
+    assert parse_etag('\t"a b"\n') == ETag.from_canonical('"a b"')
+
+
+def test_parse_etag_preserves_whitespace_inside_quotes() -> None:
+    assert parse_etag('"  spaced  "') == ETag.from_canonical('"  spaced  "')
+    assert parse_etag('"\tx\t"') == ETag.from_canonical('"\tx\t"')
+    assert parse_etag('"   "') == ETag.from_canonical('"   "')
+
+
+def test_parse_etag_weak_strips_between_prefix_and_quote_not_inside_opaque() -> None:
+    assert parse_etag('W/   "x y"') == ETag.from_canonical('W/"x y"')
+    assert parse_etag('w/\t " z "') == ETag.from_canonical('W/" z "')
+
+
+def test_parse_etag_accepts_unquoted_opaque() -> None:
+    assert parse_etag("not-quoted") == ETag.from_canonical("not-quoted")
+    assert parse_etag("59627771-19") == ETag.from_canonical("59627771-19")
+
+
+def test_parse_etag_weak_unquoted() -> None:
+    assert parse_etag("W/unquoted-token") == ETag.from_canonical("W/unquoted-token")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '"unterminated',
+        'unopened"',
+        "W/",
+        "bad token",
+        "bad,comma",
+        "a b",
+        "\x01ctrl",
+        '"dup""',
+    ],
+)
+def test_parse_etag_rejects_malformed_as_empty(raw: str) -> None:
+    assert parse_etag(raw) == EMPTY_ETAG
+
+
+def test_parse_etag_empty_quoted_opaque_is_valid_not_sentinel() -> None:
+    """RFC 9110 allows empty opaque inside quotes; do not conflate with absent sentinel."""
+    t = parse_etag('""')
+    assert t.opaque_tag == ""
+    assert not t.is_weak
+    assert not t.is_wildcard
+    assert t.raw_value == '""'
+    assert t is not EMPTY_ETAG
+    assert t != EMPTY_ETAG
+    assert t  # present (distinct from absent despite empty opaque string)
+    assert t.to_http_field_value() == '""'
+    assert format_entity_tag_for_http_header(t) == '""'
+
+
+def test_parse_etag_weak_empty_quoted_is_absent() -> None:
+    """Weak tag requires non-empty opaque — treat ``W/""`` like malformed → absent."""
+    assert parse_etag('W/""') is EMPTY_ETAG
+
+
+def test_parse_etag_wildcard_exact_and_strip() -> None:
+    star = parse_etag("*")
+    assert star.is_wildcard
+    assert star.opaque_tag == "*"
+    assert parse_etag(" \t*\n").is_wildcard
+
+
+def test_parse_double_star_is_strong_opaque_not_list_syntax() -> None:
+    """Only the lone ``*`` token is the wildcard; ``**`` is a legal opaque string."""
+    t = parse_etag("**")
+    assert not t.is_wildcard
+    assert t.opaque_tag == "**"
+
+
+# ─── Quoted-pair escapes ────────────────────────────────────────────
+
+
+def test_parse_etag_quoted_pairs_escape_quote_and_backslash() -> None:
+    t = parse_etag(r'"a\"b"')
+    assert t.opaque_tag == 'a"b'
+    t2 = parse_etag(r'"x\\y"')
+    assert t2.opaque_tag == r"x\y"
+
+
+def test_parse_etag_quoted_backslash_at_end_invalid() -> None:
+    assert parse_etag('"' + "x" + "\\") == EMPTY_ETAG
+
+
+def test_to_canonical_escapes_opaque_specials_round_trip() -> None:
+    inner = 'say "quote"\\tail'
+    t = EntityTag(opaque_tag=inner, is_weak=False, is_wildcard=False, raw_value="synthetic")
+    canon = t.to_canonical()
+    assert parse_etag(canon) == t
+    assert parse_etag(canon).opaque_tag == inner
+
+
+# ─── from_canonical ─────────────────────────────────────────────────
+
+
+def test_from_canonical_strips_outer_ows_only() -> None:
+    assert ETag.from_canonical('  "z"  ') == parse_etag('"z"')
+
+
+def test_from_canonical_blank_is_empty() -> None:
+    assert ETag.from_canonical("") is EMPTY_ETAG
+    assert ETag.from_canonical("  \t  ") is EMPTY_ETAG
+
+
+def test_from_canonical_legacy_bare_token_still_loads() -> None:
+    assert ETag.from_canonical("legacy-plain").opaque_tag == "legacy-plain"
+
+
+# ─── to_canonical / round-trip ────────────────────────────────────────
+
+
+def test_to_canonical_matches_http_field_value() -> None:
+    t = parse_etag('"z"')
+    assert t.to_canonical() == t.to_http_field_value() == '"z"'
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '"abc"',
+        'W/"weak"',
+        '"  spaced  "',
+        'W/"x y"',
+        '""',
+        "*",
+    ],
+)
+def test_round_trip_canonical_parse(raw: str) -> None:
+    tag = parse_etag(raw)
+    assert tag.to_canonical() == raw
+    assert ETag.from_canonical(tag.to_canonical()) == tag
+
+
+def test_empty_tag_canonical_and_format_are_empty_string() -> None:
+    assert EMPTY_ETAG.to_canonical() == ""
+    assert EMPTY_ETAG.to_http_field_value() == ""
+    assert str(EMPTY_ETAG) == ""
+    assert format_entity_tag_for_http_header(EMPTY_ETAG) == ""
+
+
+# ─── format_entity_tag_for_http_header ──────────────────────────────
+
+
+def test_format_entity_tag_for_http_header_matches_parse() -> None:
+    assert format_entity_tag_for_http_header(parse_etag('"z"')) == '"z"'
+    assert format_entity_tag_for_http_header(parse_etag('W/"z"')) == 'W/"z"'
+    assert format_entity_tag_for_http_header(ETag.from_canonical("plain")) == '"plain"'
+    inner = "  round  "
+    assert format_entity_tag_for_http_header(parse_etag(f'"{inner}"')) == f'"{inner}"'
+
+
+# ─── is_weak_validator ──────────────────────────────────────────────
+
+
+def test_is_weak_validator() -> None:
+    assert is_weak_validator(EMPTY_ETAG) is False
+    assert is_weak_validator(ETag.from_canonical("abc")) is False
+    assert is_weak_validator(ETag.from_canonical("W/x")) is True
+    assert is_weak_validator(parse_etag('W/"z"')) is True
+
+
+def test_empty_etag_singleton_identity() -> None:
+    assert (
+        EntityTag(
+            opaque_tag=None,
+            is_weak=False,
+            is_wildcard=False,
+            raw_value="",
+        )
+        == EMPTY_ETAG
+    )
+    assert (
+        EntityTag(
+            opaque_tag=None,
+            is_weak=False,
+            is_wildcard=False,
+            raw_value="",
+        )
+        is not EMPTY_ETAG
+    )
+
+
+def test_pickle_absent_and_strong_empty_round_trip() -> None:
+    import pickle
+
+    restored_absent = pickle.loads(pickle.dumps(EMPTY_ETAG))  # noqa: S301
+    assert restored_absent == EMPTY_ETAG
+    assert restored_absent.to_http_field_value() == ""
+
+    strong_empty = parse_etag('""')
+    restored_se = pickle.loads(pickle.dumps(strong_empty))  # noqa: S301
+    assert restored_se == strong_empty
+    assert restored_se.to_http_field_value() == '""'
+
+
+# ─── __eq__, __hash__, __repr__, __str__ ────────────────────────────
+
+
+def test_eq_respects_semantics_ignores_raw_value() -> None:
+    a = EntityTag.parse_header_value('  "same"  ')
+    b = EntityTag.parse_header_value('"same"')
+    assert a == b
+    assert hash(a) == hash(b)
+    assert a.raw_value != b.raw_value
+
+
+def test_eq_notimplemented_for_foreign_type() -> None:
+    assert EMPTY_ETAG.__eq__(object()) is NotImplemented
+
+
+def test_repr_contains_semantic_fields_not_raw() -> None:
+    r = repr(parse_etag('"x"'))
+    assert "opaque_tag='x'" in r
+    assert "raw_value" not in r
+
+
+def test_str_matches_http_field_value() -> None:
+    t = parse_etag('W/"w"')
+    assert str(t) == t.to_http_field_value()
+
+
+# ─── strong_equals / weak_equals / usable_for_byte_range ────────────
+
+
+def test_strong_equals_only_when_both_strong_same_opaque() -> None:
+    s = parse_etag('"a"')
+    assert s.strong_equals(parse_etag('"a"'))
+    assert not s.strong_equals(parse_etag('W/"a"'))
+    assert not s.strong_equals(parse_etag('"b"'))
+    assert not s.strong_equals(parse_etag("*"))
+    assert not EMPTY_ETAG.strong_equals(s)
+
+
+def test_weak_equals_ignores_weak_bit_matches_opaque_only() -> None:
+    a = parse_etag('"x"')
+    w = parse_etag('W/"x"')
+    assert not a.weak_equals(EMPTY_ETAG)
+    assert not parse_etag("*").weak_equals(a)
+    assert a.weak_equals(w)
+    assert w.weak_equals(a)
+
+
+def test_strong_equals_weak_equals_false_for_non_entity_tag() -> None:
+    t = parse_etag('"x"')
+    assert t.strong_equals('"x"') is False
+    assert t.weak_equals('"x"') is False
+
+
+def test_usable_for_byte_range_precondition() -> None:
+    assert EMPTY_ETAG.usable_for_byte_range_precondition is False
+    assert parse_etag("*").usable_for_byte_range_precondition is False
+    assert parse_etag('W/"z"').usable_for_byte_range_precondition is False
+    assert parse_etag('"ok"').usable_for_byte_range_precondition is True
+    assert parse_etag('""').usable_for_byte_range_precondition is True
+
+
+def test_strong_equals_strong_empty_opaque() -> None:
+    assert parse_etag('""').strong_equals(parse_etag('""'))
+    assert not parse_etag('""').strong_equals(EMPTY_ETAG)
+
+
+# ─── Integration smoke vs Url NewType ───────────────────────────────
+
+
+def test_entity_tag_is_concrete_class_distinct_from_newtyped_url() -> None:
+    url = parse_url("http://example.com/")
+    etag = parse_etag('"abc"')
+    assert type(url) is str
+    assert type(etag).__name__ == "EntityTag"
+
+
+def test_parse_etag_direct_same_symbol_export_path() -> None:
+    assert parse_etag_direct('"q"') == parse_etag('"q"')
+
+
+def test_parse_etag_accepts_unicode_unquoted_opaque() -> None:
+    """Unquoted opaques allow Unicode like decoded header libraries (e.g. httpx)."""
+    q = parse_etag('"cafè"')
+    u = parse_etag("cafè")
+    assert q.opaque_tag == u.opaque_tag == "cafè"
+    assert parse_etag('W/"cafè"').opaque_tag == parse_etag("W/cafè").opaque_tag == "cafè"
+    assert parse_etag("W/cafè").is_weak
+    latin = parse_etag("bad\xff")
+    assert latin.opaque_tag == "bad\xff"
+
+
+# ─── Controls / separators rejected in unquoted ──────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad_unquoted",
+    ["~bad\x7f", "\x01ctrl"],
+)
+def test_parse_rejects_controls_and_separators_unquoted(bad_unquoted: str) -> None:
+    assert parse_etag(bad_unquoted) == EMPTY_ETAG
+
+
+def test_private_helpers_edge_cases() -> None:
+    """Cover trivial branches in grammar helpers (normally unreachable via public API)."""
+    assert etag_module._opaque_ok_unquoted_token("") is False
+    assert etag_module._parse_leading_quoted_opaque_whole("not-a-quoted-string") is None
+    assert etag_module._parse_leading_quoted_opaque_whole('""') == ""
+
+
+def test_weak_tag_escapes_opaque_in_canonical_round_trip() -> None:
+    inner = 'w"k\\'
+    w = EntityTag(opaque_tag=inner, is_weak=True, is_wildcard=False, raw_value="")
+    assert parse_etag(w.to_canonical()).opaque_tag == inner
+    assert parse_etag(w.to_canonical()).is_weak

--- a/tests/test_handle_response_redirect.py
+++ b/tests/test_handle_response_redirect.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from pyhaul._engine_common import PrepareHaul, handle_response
-from pyhaul._types import ETag, HaulState, UnexpectedStatusError, Url
+from pyhaul._types import EMPTY_ETAG, HaulState, UnexpectedStatusError, Url
 from pyhaul.transport._headers import TransportHeaders
 
 
@@ -19,7 +19,7 @@ def _minimal_prep() -> PrepareHaul:
         ctrl_path=Path("/tmp/pyhaul-test.bin.part.ctrl"),
         start=0,
         cursor=0,
-        stored_etag=ETag(""),
+        stored_etag=EMPTY_ETAG,
         hashes=[],
         tail_hash=None,
         block_size=8 * 1024 * 1024,

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -52,6 +52,21 @@ class TestFromPairs:
         assert list(h) == ["x-a", "x-b"]
 
 
+class TestDirectConstruction:
+    """``TransportHeaders(...)`` must normalize like :meth:`TransportHeaders.from_pairs`."""
+
+    def test_bracket_access_case_insensitive_for_mixed_case_constructor_names(self) -> None:
+        h = TransportHeaders([("My-Header", "Value")])
+        assert h["My-Header"] == "Value"
+        assert h["my-header"] == "Value"
+        assert h.raw_items == (("my-header", "Value"),)
+
+    def test_constructor_strips_names_and_values(self) -> None:
+        h = TransportHeaders([("  Z  ", "  padded  ")])
+        assert h["z"] == "padded"
+        assert list(h) == ["z"]
+
+
 class TestFromMapping:
     def test_round_trip(self) -> None:
         h = TransportHeaders.from_mapping({"Content-Length": "42", "ETag": '"z"'})
@@ -223,6 +238,24 @@ class TestEqualityAndHashing:
         h = TransportHeaders.from_pairs([("content-type", "text/html")])
         assert h == {"content-type": "text/html"}
 
+    def test_eq_plain_mapping_false_when_self_has_duplicate_field_names(self) -> None:
+        """``Mapping.items()`` collapses to one value per key — cannot match full wire state.
+
+        A :class:`dict` (or any mapping consumed via ``dict(their.items())``) cannot
+        represent duplicate header names. Equality must not succeed on first-value
+        coincidence alone.
+        """
+        h = TransportHeaders.from_pairs(
+            [
+                ("Set-Cookie", "a=1"),
+                ("Set-Cookie", "b=2"),
+            ]
+        )
+        assert h.get_all("set-cookie") == ("a=1", "b=2")
+        naive_single = {"set-cookie": "a=1"}
+        assert h != naive_single
+        assert naive_single != h
+
     def test_ne_with_non_mapping(self) -> None:
         h = TransportHeaders.from_pairs([("A", "1")])
         assert h != 42
@@ -351,8 +384,17 @@ class TestRepr:
     def test_basic_repr(self) -> None:
         h = TransportHeaders.from_pairs([("Content-Type", "text/html")])
         r = repr(h)
-        assert "content-type" in r
-        assert "text/html" in r
+        assert r == "TransportHeaders([('content-type', 'text/html')])"
+
+    def test_repr_list_shape_preserves_duplicate_field_names(self) -> None:
+        """List-of-tuples ``repr`` mirrors wire rows (dict-shaped ``repr`` would lie)."""
+        h = TransportHeaders.from_pairs(
+            [
+                ("X-Trace", "first"),
+                ("X-Trace", "second"),
+            ]
+        )
+        assert repr(h) == "TransportHeaders([('x-trace', 'first'), ('x-trace', 'second')])"
 
     def test_redacts_authorization(self) -> None:
         h = TransportHeaders.from_pairs(
@@ -384,10 +426,10 @@ class TestRepr:
         assert "xyz" not in r
         assert "[redacted]" in r
 
-
-# ======================================================================
-# Raw access
-# ======================================================================
+    def test_repr_duplicate_set_cookie_rows_redacted_but_distinct(self) -> None:
+        """Sensitive names stay redacted; tuple count still shows multiple wire rows."""
+        h = TransportHeaders.from_pairs([("Set-Cookie", "a=1"), ("Set-Cookie", "b=2")])
+        assert repr(h) == ("TransportHeaders([('set-cookie', '[redacted]'), ('set-cookie', '[redacted]')])")
 
 
 class TestToSafeDict:
@@ -431,6 +473,10 @@ class TestWire:
     def test_to_wire(self) -> None:
         h = TransportHeaders.from_pairs([("Content-Type", "text/html"), ("ETag", '"v1"')])
         assert h.to_wire() == b'content-type: text/html\r\netag: "v1"\r\n'
+
+    def test_to_wire_utf8_non_ascii(self) -> None:
+        h = TransportHeaders.from_pairs([("X-Greeting", "café")])
+        assert h.to_wire() == "x-greeting: café\r\n".encode()
 
 
 class TestPickle:

--- a/tests/test_integrity_validation.py
+++ b/tests/test_integrity_validation.py
@@ -95,7 +95,7 @@ def test_resume_tail_corruption_detected(tmp_path: Path) -> None:
         start=0,
         extent=20,
         valid_length=15,
-        etag=ETag('"v1"'),
+        etag=ETag.from_canonical("v1"),
         block_size=10,
         hashes=[_get_hash(block1)],
         tail_hash=_get_hash(tail_good),  # We thought it was GOOD when we saved ctrl
@@ -128,7 +128,7 @@ def test_resume_tail_truncation_detected(tmp_path: Path) -> None:
         start=0,
         extent=20,
         valid_length=15,
-        etag=ETag('"v1"'),
+        etag=ETag.from_canonical("v1"),
         block_size=10,
         hashes=[b"H" * 32],
     )

--- a/tests/test_integrity_validation.py
+++ b/tests/test_integrity_validation.py
@@ -57,6 +57,16 @@ class MockSession:
         self._call_index += 1
         yield self.responses[idx]
 
+    @contextmanager
+    def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> Iterator[TransportResponse]:
+        raise RuntimeError("MockSession.stream_head is not used by integrity tests")
+
 
 def _make_206_response(body: bytes, start: int, total: int | None, etag: str = '"test"') -> MockResponse:
     end = start + len(body) - 1

--- a/tests/test_live_torture.py
+++ b/tests/test_live_torture.py
@@ -132,16 +132,16 @@ def test_200_truncation_restarts_from_zero(http: HttpTest) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _write_synthetic_ctrl(http: HttpTest, *, valid_length: int, extent: int, etag: str = '"test-etag"') -> None:
+def _write_synthetic_ctrl(http: HttpTest, *, valid_length: int, extent: int, etag: str = "test-etag") -> None:
     """Stage a .ctrl as if a prior haul wrote ``valid_length`` bytes."""
-    from pyhaul._types import ETag
+    from pyhaul.etag import parse_etag
 
     cp = Checkpoint(
         version=LATEST_VERSION,
         start=0,
         extent=extent,
         valid_length=valid_length,
-        etag=ETag(etag),
+        etag=parse_etag(etag),
         block_size=8 * 1024 * 1024,
         hashes=[],
         reported_length=extent,

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from pyhaul._types import ControlFileError, ETag
+from pyhaul._types import EMPTY_ETAG, ControlFileError, ETag
 from pyhaul.checkpoint import LATEST_VERSION, Checkpoint, registry
 from pyhaul.persist import (
     ctrl_path_for,
@@ -24,7 +24,7 @@ def _make_checkpoint(**overrides: object) -> Checkpoint:
         "start": 0,
         "extent": 104857600,
         "valid_length": 67108864,
-        "etag": ETag('"abc123"'),
+        "etag": ETag.from_canonical("abc123"),
         "block_size": 8 * 1024 * 1024,
         "hashes": [],
         "reported_length": 104857600,
@@ -74,10 +74,10 @@ class TestRoundTrip:
         assert restored.reported_length is None
 
     def test_empty_etag(self) -> None:
-        cp = _make_checkpoint(etag=ETag(""))
+        cp = _make_checkpoint(etag=EMPTY_ETAG)
         raw = registry.dump(cp)
         restored = registry.load(raw)
-        assert restored.etag == ""
+        assert restored.etag == EMPTY_ETAG
 
     def test_zero_valid_length(self) -> None:
         cp = _make_checkpoint(valid_length=0)

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,0 +1,187 @@
+"""Tests for ``probe`` / ``probe_async`` metadata discovery."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator, Mapping
+from contextlib import asynccontextmanager, contextmanager
+
+import pytest
+
+from pyhaul._probe_common import run_probe_async, run_probe_sync
+from pyhaul._types import UnexpectedStatusError, Url
+from pyhaul.transport.protocols import (
+    AsyncTransportResponse,
+    AsyncTransportSession,
+    TransportResponse,
+    TransportSession,
+)
+from pyhaul.transport.types import TransportHeaders, TransportRequestOptions
+
+_URL = "https://example.com/resource.bin"
+
+
+class _Resp:
+    """Minimal transport response with optional body for ranged GET."""
+
+    __slots__ = ("_body", "headers", "status_code")
+
+    def __init__(self, status_code: int, headers: dict[str, str], body: bytes = b"") -> None:
+        self.status_code = status_code
+        self.headers = TransportHeaders.from_mapping(headers)
+        self._body = body
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def iter_raw_bytes(self, *, chunk_size: int) -> Iterator[bytes]:
+        del chunk_size
+        if self._body:
+            yield self._body
+
+    async def aiter_raw_bytes(self, *, chunk_size: int) -> AsyncIterator[bytes]:
+        del chunk_size
+        if self._body:
+            yield self._body
+
+
+class FakeSyncTransport(TransportSession):
+    def __init__(self, head: _Resp, get: _Resp) -> None:
+        self._head = head
+        self._get = get
+        self.head_calls = 0
+        self.get_calls = 0
+
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        return headers
+
+    @contextmanager
+    def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> Iterator[TransportResponse]:
+        del url, headers, options
+        self.head_calls += 1
+        yield self._head
+
+    @contextmanager
+    def stream_get(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> Iterator[TransportResponse]:
+        del url, headers, options
+        self.get_calls += 1
+        yield self._get
+
+
+class FakeAsyncTransport(AsyncTransportSession):
+    def __init__(self, head: _Resp, get: _Resp) -> None:
+        self._head = head
+        self._get = get
+        self.head_calls = 0
+        self.get_calls = 0
+
+    def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
+        return headers
+
+    @asynccontextmanager
+    async def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AsyncIterator[AsyncTransportResponse]:
+        del url, headers, options
+        self.head_calls += 1
+        yield self._head
+
+    @asynccontextmanager
+    async def stream_get(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AsyncIterator[AsyncTransportResponse]:
+        del url, headers, options
+        self.get_calls += 1
+        yield self._get
+
+
+def test_probe_sync_head_complete_skips_get() -> None:
+    head = _Resp(
+        200,
+        {
+            "Accept-Ranges": "bytes",
+            "ETag": '"abc"',
+            "Content-Disposition": 'attachment; filename="a.bin"',
+            "Content-Length": "100",
+        },
+    )
+    bad = _Resp(500, {})
+    t = FakeSyncTransport(head, bad)
+    r = run_probe_sync(t, _URL, headers=None, options=None)
+    assert t.head_calls == 1
+    assert t.get_calls == 0
+    assert not r.ranged_get_used
+    assert r.total_length == 100
+    assert r.supports_concurrent_byte_ranges
+    assert r.status_code == 200
+
+
+def test_probe_sync_range_followup_fills_total() -> None:
+    head = _Resp(200, {"Content-Length": "50"})
+    get = _Resp(
+        206,
+        {
+            "Content-Range": "bytes 0-0/999",
+            "Content-Length": "1",
+            "Accept-Ranges": "bytes",
+            "ETag": '"z"',
+        },
+        body=b"x",
+    )
+    t = FakeSyncTransport(head, get)
+    r = run_probe_sync(t, _URL, headers=None, options=None)
+    assert t.get_calls == 1
+    assert r.ranged_get_used
+    assert r.total_length == 999
+    assert r.status_code == 206
+
+
+def test_probe_sync_unexpected_status_raises() -> None:
+    head = _Resp(404, {})
+    get = _Resp(404, {})
+    t = FakeSyncTransport(head, get)
+    with pytest.raises(UnexpectedStatusError) as ei:
+        run_probe_sync(t, _URL, headers=None, options=None)
+    assert ei.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_probe_async_range_followup() -> None:
+    head = _Resp(200, {})
+    get = _Resp(
+        206,
+        {"Content-Range": "bytes 0-0/42", "Content-Length": "1", "Accept-Ranges": "bytes"},
+        body=b"!",
+    )
+    t = FakeAsyncTransport(head, get)
+    r = await run_probe_async(t, _URL, headers=None, options=None)
+    assert t.head_calls == 1
+    assert t.get_calls == 1
+    assert r.total_length == 42
+
+
+def test_public_exports_probe_result() -> None:
+    from pyhaul import ProbeResult, probe, probe_async
+
+    assert ProbeResult.__name__ == "ProbeResult"
+    assert callable(probe)
+    assert callable(probe_async)

--- a/tests/test_proxy_transport_session.py
+++ b/tests/test_proxy_transport_session.py
@@ -45,10 +45,22 @@ class StubTransport(TransportSession):
     def __init__(self) -> None:
         self.prepared_sequence: list[TransportHeaders] = []
         self.stream_get_calls = 0
+        self.stream_head_calls = 0
 
     def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
         self.prepared_sequence.append(headers)
         return headers.with_added("X-Inner", "1")
+
+    @contextmanager
+    def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> Iterator[StubResponse]:
+        self.stream_head_calls += 1
+        yield StubResponse()
 
     @contextmanager
     def stream_get(
@@ -153,10 +165,22 @@ class _MiniAsyncResp:
 class AsyncStubTransport(AsyncTransportSession):
     def __init__(self) -> None:
         self.prepared: list[TransportHeaders] = []
+        self.stream_head_calls = 0
 
     def prepare_headers(self, headers: TransportHeaders) -> TransportHeaders:
         self.prepared.append(headers)
         return headers.with_added("Y-Inner", "1")
+
+    @asynccontextmanager
+    async def stream_head(
+        self,
+        url: Url,
+        *,
+        headers: Mapping[str, str],
+        options: TransportRequestOptions | None = None,
+    ) -> AsyncIterator[_MiniAsyncResp]:
+        self.stream_head_calls += 1
+        yield _MiniAsyncResp()
 
     @asynccontextmanager
     async def stream_get(
@@ -196,3 +220,14 @@ def test_stream_get_forwards_to_inner() -> None:
         assert resp.status_code == 200
 
     assert inner.stream_get_calls == 1
+
+
+def test_stream_head_forwards_to_inner() -> None:
+    inner = StubTransport()
+    proxy = transport_session_proxy().around(inner).build()
+    u = parse_url("http://example.test/file")
+
+    with proxy.stream_head(u, headers={"Accept": "*/*"}) as resp:
+        assert resp.status_code == 200
+
+    assert inner.stream_head_calls == 1

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -200,17 +200,32 @@ class TestUnexpectedStatusError:
         assert str(exc) == "rate limited"
         assert exc.reason == "rate limited"
 
-    def test_is_transient_429(self) -> None:
+    def test_is_transient_common_overload_and_upstream_codes(self) -> None:
+        assert self._make(408).is_transient is True
+        assert self._make(425).is_transient is True
         assert self._make(429).is_transient is True
-
-    def test_is_transient_503(self) -> None:
+        assert self._make(500).is_transient is True
+        assert self._make(502).is_transient is True
         assert self._make(503).is_transient is True
+        assert self._make(504).is_transient is True
+        assert self._make(520).is_transient is True
+        assert self._make(522).is_transient is True
+        assert self._make(524).is_transient is True
 
     def test_is_not_transient_404(self) -> None:
         assert self._make(404).is_transient is False
 
-    def test_is_not_transient_500(self) -> None:
-        assert self._make(500).is_transient is False
+    def test_is_server_error_5xx(self) -> None:
+        assert self._make(500).is_server_error is True
+        assert self._make(503).is_server_error is True
+        assert self._make(599).is_server_error is True
+
+    def test_is_not_server_error_4xx(self) -> None:
+        assert self._make(429).is_server_error is False
+        assert self._make(404).is_server_error is False
+
+    def test_is_server_error_excludes_non_http_class(self) -> None:
+        assert self._make(200).is_server_error is False
 
     def test_retry_after_present(self) -> None:
         exc = self._make()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,6 +3,9 @@ PartialHaulError (exception), and HaulState (mutable bag)."""
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from email.utils import format_datetime
+
 import pytest
 
 from pyhaul import (
@@ -16,7 +19,7 @@ from pyhaul import (
     parse_etag,
     parse_url,
 )
-from pyhaul._types import EMPTY_ETAG, EMPTY_URL
+from pyhaul._types import EMPTY_ETAG, EMPTY_URL, _retry_after_raw_to_seconds
 from pyhaul.transport._headers import TransportHeaders
 
 
@@ -230,10 +233,18 @@ class TestUnexpectedStatusError:
     def test_retry_after_present(self) -> None:
         exc = self._make()
         assert exc.retry_after == "120"
+        assert exc.retry_after_seconds == 120.0
 
     def test_retry_after_absent(self) -> None:
         exc = self._make(headers=TransportHeaders())
         assert exc.retry_after is None
+        assert exc.retry_after_seconds is None
+
+    def test_retry_after_seconds_invalid_header(self) -> None:
+        exc = self._make(
+            headers=TransportHeaders.from_pairs([("Retry-After", "not-a-number-or-date")]),
+        )
+        assert exc.retry_after_seconds is None
 
     def test_catchable_as_haul_error(self) -> None:
         with pytest.raises(HaulError):
@@ -243,3 +254,40 @@ class TestUnexpectedStatusError:
         exc = self._make()
         with pytest.raises(AttributeError):
             exc.headers.x = "nope"
+
+
+class TestRetryAfterParsing:
+    """Unit tests for :func:`pyhaul._types._retry_after_raw_to_seconds`."""
+
+    def test_delay_seconds(self) -> None:
+        assert _retry_after_raw_to_seconds("45", now=lambda: 0.0) == 45.0
+
+    def test_whitespace_delay(self) -> None:
+        assert _retry_after_raw_to_seconds("  90  ", now=lambda: 0.0) == 90.0
+
+    def test_http_date_future(self) -> None:
+        fixed_ts = 1_700_000_000.0
+        when = datetime.fromtimestamp(fixed_ts + 37.0, tz=UTC)
+        assert _retry_after_raw_to_seconds(format_datetime(when), now=lambda: fixed_ts) == pytest.approx(37.0)
+
+    def test_http_date_past_clamps_zero(self) -> None:
+        fixed_ts = 1_700_000_000.0
+        when = datetime.fromtimestamp(fixed_ts - 60.0, tz=UTC)
+        assert _retry_after_raw_to_seconds(format_datetime(when), now=lambda: fixed_ts) == 0.0
+
+    def test_large_delay_integer_passes_through(self) -> None:
+        assert _retry_after_raw_to_seconds("999999", now=lambda: 0.0) == 999999.0
+
+    def test_large_http_date_passes_through(self) -> None:
+        fixed_ts = 1_700_000_000.0
+        delta_sec = 999_999.0
+        when = datetime.fromtimestamp(fixed_ts + delta_sec, tz=UTC)
+        assert _retry_after_raw_to_seconds(format_datetime(when), now=lambda: fixed_ts) == pytest.approx(
+            delta_sec,
+        )
+
+    def test_none_absent(self) -> None:
+        assert _retry_after_raw_to_seconds(None, now=lambda: 0.0) is None
+
+    def test_empty_string(self) -> None:
+        assert _retry_after_raw_to_seconds("   ", now=lambda: 0.0) is None

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,4 @@
-"""Tests for parse_url / parse_etag branding factories, CompleteHaul,
-PartialHaulError (exception), and HaulState (mutable bag)."""
+"""Tests for parse_url, CompleteHaul, PartialHaulError (exception), and HaulState."""
 
 from __future__ import annotations
 
@@ -9,17 +8,16 @@ from email.utils import format_datetime
 import pytest
 
 from pyhaul import (
+    EMPTY_ETAG,
     CompleteHaul,
     ETag,
     HaulError,
     HaulState,
     PartialHaulError,
     UnexpectedStatusError,
-    Url,
-    parse_etag,
     parse_url,
 )
-from pyhaul._types import EMPTY_ETAG, EMPTY_URL, _retry_after_raw_to_seconds
+from pyhaul._types import EMPTY_URL, _retry_after_raw_to_seconds
 from pyhaul.transport._headers import TransportHeaders
 
 
@@ -64,64 +62,15 @@ def test_parse_url_rejects_missing_host(raw: str) -> None:
         parse_url(raw)
 
 
-def test_parse_etag_strong_and_weak_are_preserved_verbatim() -> None:
-    assert parse_etag('"abc123"') == '"abc123"'
-    assert parse_etag('W/"weak-hash"') == 'W/"weak-hash"'
-
-
-def test_parse_etag_strips_whitespace() -> None:
-    assert parse_etag('  "abc"  ') == '"abc"'
-
-
-@pytest.mark.parametrize("raw", ["", "   ", "\t"])
-def test_parse_etag_empty_returns_empty_sentinel(raw: str) -> None:
-    result = parse_etag(raw)
-    assert result == EMPTY_ETAG
-    assert result == ""
-
-
-@pytest.mark.parametrize(
-    "raw",
-    [
-        "not-quoted",
-        '"unterminated',
-        'unopened"',
-        '"',
-        "W/unquoted",
-    ],
-)
-def test_parse_etag_rejects_malformed_as_empty(raw: str) -> None:
-    """Malformed ETags become EMPTY_ETAG rather than raise — we refuse to
-    echo garbage back in If-Range, but don't want to blow up the download."""
-    assert parse_etag(raw) == EMPTY_ETAG
-
-
-def test_parse_etag_type_error_on_non_string() -> None:
-    with pytest.raises(TypeError):
-        parse_etag(None)
-    with pytest.raises(TypeError):
-        parse_etag(b'"bytes"')
-
-
-def test_newtype_identity_at_runtime() -> None:
-    """NewType is a no-op at runtime — the brand only lives in mypy's view."""
-    url = parse_url("http://example.com/")
-    etag = parse_etag('"abc"')
-    assert type(url) is str  # not a subclass
-    assert type(etag) is str
-    assert Url("x") == "x"
-    assert ETag("y") == "y"
-
-
 def test_download_complete_carries_success_only_fields() -> None:
     result = CompleteHaul(
         elapsed=1.0,
         sha256="abc",
-        etag=ETag('"v1"'),
+        etag=ETag.from_canonical("v1"),
         content_type="application/octet-stream",
     )
     assert result.sha256 == "abc"
-    assert result.etag == '"v1"'
+    assert result.etag == ETag.from_canonical("v1")
 
 
 def test_download_partial_is_exception() -> None:


### PR DESCRIPTION
## Summary

- **Probe**: `probe()` / `probe_async()`, `ProbeResult`, HEAD plus optional ranged GET metadata discovery; `stream_head` on transports.
- **Engine / headers**: EntityTag and If-Range handling, 206 recovery paths, async progress callbacks, `TransportHeaders` fixes.
- **Types / etag**: `EntityTag` module, `retry_after_seconds`, transient HTTP statuses and `is_server_error`, related re-exports.
- **HTTP**: use stdlib `HTTPStatus` instead of local numeric constants.
- **Docs**: README, specs, and async/cancellation notes.

See commits on `feat/probe-support` vs `main` for the full changelog.