### PR TITLE
ci: lockfile vs config matrix + workflow fan-out (#architecture)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,10 @@ jobs:
             os_sensitive:
               - 'src/pyhaul/alloc.py'
               - 'src/pyhaul/fs.py'
-            deps:
-              - 'pyproject.toml'
+            lockfile:
               - 'uv.lock'
+            config:
+              - 'pyproject.toml'
             ci:
               - '.github/workflows/**'
             docs:
@@ -59,17 +60,20 @@ jobs:
           CHANGED_SRC: ${{ steps.changes.outputs.src }}
           CHANGED_TESTS: ${{ steps.changes.outputs.tests }}
           CHANGED_OS: ${{ steps.changes.outputs.os_sensitive }}
-          CHANGED_DEPS: ${{ steps.changes.outputs.deps }}
+          CHANGED_LOCK: ${{ steps.changes.outputs.lockfile }}
+          CHANGED_CONFIG: ${{ steps.changes.outputs.config }}
           CHANGED_CI: ${{ steps.changes.outputs.ci }}
         shell: bash
         run: |
-          if [[ "$ALWAYS_FULL" == "true" || "$CHANGED_SRC" == "true" || "$CHANGED_TESTS" == "true" || "$CHANGED_DEPS" == "true" || "$CHANGED_CI" == "true" ]]; then
+          # run-tests: lockfile or pyproject config changes imply dependency or packaging inputs may affect installs/tests.
+          if [[ "$ALWAYS_FULL" == "true" || "$CHANGED_SRC" == "true" || "$CHANGED_TESTS" == "true" || "$CHANGED_LOCK" == "true" || "$CHANGED_CONFIG" == "true" || "$CHANGED_CI" == "true" ]]; then
             echo "run-tests=true" >> "$GITHUB_OUTPUT"
           else
             echo "run-tests=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if [[ "$ALWAYS_FULL" == "true" || "$CHANGED_OS" == "true" || "$CHANGED_DEPS" == "true" || "$CHANGED_CI" == "true" ]]; then
+          # Tri-OS: trunk merges, lockfile changes, CI workflow edits, or fs-sensitive code paths — not pyproject-only bumps (e.g. release-please version PRs).
+          if [[ "$ALWAYS_FULL" == "true" || "$CHANGED_OS" == "true" || "$CHANGED_LOCK" == "true" || "$CHANGED_CI" == "true" ]]; then
             echo 'os-matrix=["ubuntu-latest","windows-latest","macos-latest"]' >> "$GITHUB_OUTPUT"
             echo "coverage-floor=85" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,8 @@ on:
     paths:
       - "docs/**"
       - "properdocs.yml"
-      - "src/pyhaul/**"
+      - "**/*.md"
+      - "src/**"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           enable-cache: false
 
+      # Ephemeral edit on the runner only — never committed or pushed to main.
       - name: Stamp dev version into pyproject.toml
         id: ver
         shell: python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,30 +27,9 @@ jobs:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  codeql-gate:
-    name: CodeQL gate
-    needs: release-please
-    if: needs.release-please.outputs.released == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
-        with:
-          languages: python
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
-        with:
-          category: /language:python
-
   build:
     name: Build & inspect package
-    needs: [release-please, codeql-gate]
+    needs: [release-please]
     if: needs.release-please.outputs.released == 'true'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
Implements the CI migration plan (Phases 1–3): split dependency-related path filters so **pyproject-only** release bumps stay **ubuntu-only** while **lockfile**, **ci**, **ALWAYS_FULL**, and **os_sensitive** still trigger the **tri-OS** matrix; widen **docs** workflow push paths; remove redundant **CodeQL** gate from **release** (analysis remains in **codeql.yml**); document **nightly** runner-local **pyproject** stamp.

## Notes
- **CodeQL:** Tag releases no longer run the duplicate **codeql-gate** job; **main**/scheduled/path-triggered analysis is unchanged via **codeql.yml**.
- **dependency-submission.yml** already scoped **uv.lock**; no change.

## Verification
- [ ] Merge / observe **Plan** job on a release-please-style PR (config-only): expect **ubuntu-only** matrix.
- [ ] Push to **main**: **ALWAYS_FULL** should keep **tri-OS**.
- [ ] Optional: `gh workflow run nightly.yml --ref main` after merge.