### PR TITLE
ci: harden attestation verification, Renovate tiering, and path-filter scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,13 @@ jobs:
             config:
               - 'pyproject.toml'
             ci:
-              - '.github/workflows/**'
+              - '.github/**'
+            tooling:
+              - 'tools/**'
+              - 'scripts/**'
+              - 'justfile'
+              - 'renovate.json'
+              - '.pre-commit-config.yaml'
             docs:
               - 'docs/**'
               - 'properdocs.yml'
@@ -63,17 +69,18 @@ jobs:
           CHANGED_LOCK: ${{ steps.changes.outputs.lockfile }}
           CHANGED_CONFIG: ${{ steps.changes.outputs.config }}
           CHANGED_CI: ${{ steps.changes.outputs.ci }}
+          CHANGED_TOOLING: ${{ steps.changes.outputs.tooling }}
         shell: bash
         run: |
-          # run-tests: lockfile or pyproject config changes imply dependency or packaging inputs may affect installs/tests.
-          if [[ "$ALWAYS_FULL" == "true" || "$CHANGED_SRC" == "true" || "$CHANGED_TESTS" == "true" || "$CHANGED_LOCK" == "true" || "$CHANGED_CONFIG" == "true" || "$CHANGED_CI" == "true" ]]; then
+          # run-tests: lockfile, config, CI, or tooling changes may affect build/test/security outputs.
+          if [[ "$ALWAYS_FULL" == "true" || "$CHANGED_SRC" == "true" || "$CHANGED_TESTS" == "true" || "$CHANGED_LOCK" == "true" || "$CHANGED_CONFIG" == "true" || "$CHANGED_CI" == "true" || "$CHANGED_TOOLING" == "true" ]]; then
             echo "run-tests=true" >> "$GITHUB_OUTPUT"
           else
             echo "run-tests=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Tri-OS: trunk merges, lockfile changes, CI workflow edits, or fs-sensitive code paths.
-          if [[ "$ALWAYS_FULL" == "true" || "$CHANGED_OS" == "true" || "$CHANGED_LOCK" == "true" || "$CHANGED_CI" == "true" ]]; then
+          # Tri-OS: trunk merges, lockfile changes, CI/tooling edits, or fs-sensitive code paths.
+          if [[ "$ALWAYS_FULL" == "true" || "$CHANGED_OS" == "true" || "$CHANGED_LOCK" == "true" || "$CHANGED_CI" == "true" || "$CHANGED_TOOLING" == "true" ]]; then
             echo 'os-matrix=["ubuntu-latest","windows-latest","macos-latest"]' >> "$GITHUB_OUTPUT"
             echo "coverage-floor=85" >> "$GITHUB_OUTPUT"
           else
@@ -322,10 +329,26 @@ jobs:
       - name: Verify import
         run: python -c "import pyhaul; print(pyhaul.__version__)"
 
+  meta:
+    name: Validate CI config
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: actionlint
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s
+          ./actionlint -color
+      - name: Validate renovate config
+        run: npx --yes --package renovate -- renovate-config-validator renovate.json
+
   ci-ok:
     name: CI green
     if: always()
-    needs: [lint, build, test-stable, test-prospective, install-dev, coverage]
+    needs: [lint, build, test-stable, test-prospective, install-dev, coverage, meta]
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,21 @@ jobs:
       name: pypi
       url: https://pypi.org/p/pyhaul
     permissions:
+      contents: read # gh attestation verify needs to read repo attestations
       id-token: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
           path: dist/
+      - name: Verify build attestations before publish
+        run: |
+          for f in dist/*; do
+            echo "Verifying attestation: $f"
+            gh attestation verify "$f" --repo "$GITHUB_REPOSITORY"
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   upload-immutable-assets:

--- a/renovate.json
+++ b/renovate.json
@@ -73,9 +73,31 @@
       ]
     },
     {
-      "description": "Group GitHub Actions updates into a single PR",
-      "groupName": "github actions",
-      "matchManagers": ["github-actions"]
+      "description": "Privileged actions: individual PRs, 14-day cooldown, manual review required",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "pypa/gh-action-pypi-publish",
+        "hynek/build-and-inspect-python-package",
+        "codecov/codecov-action",
+        "actions/checkout",
+        "googleapis/release-please-action"
+      ],
+      "groupName": null,
+      "minimumReleaseAge": "14 days",
+      "labels": ["security", "privileged-action"],
+      "prPriority": 10
+    },
+    {
+      "description": "Low-privilege actions: grouped, standard cooldown",
+      "matchManagers": ["github-actions"],
+      "excludePackageNames": [
+        "pypa/gh-action-pypi-publish",
+        "hynek/build-and-inspect-python-package",
+        "codecov/codecov-action",
+        "actions/checkout",
+        "googleapis/release-please-action"
+      ],
+      "groupName": "github actions (low-privilege)"
     },
     {
       "description": "Automerge non-major dev/lint dependency updates (skip 0.x)",


### PR DESCRIPTION
## Summary

- **Attestation verification** (`release.yml`): verify build attestations with `gh attestation verify` before publishing to PyPI, closing the soft link between build and publish jobs
- **Renovate tiering** (`renovate.json`): separate privileged GitHub Actions (pypi-publish, checkout, BAIPP, codecov) into individual PRs with 14-day cooldown and `security`/`privileged-action` labels; low-privilege actions remain grouped
- **Path-filter hardening** (`ci.yml`): widen `ci` filter to `.github/**`, add `tooling` filter for `tools/`, `scripts/`, `justfile`, `renovate.json`, `.pre-commit-config.yaml`; wire `CHANGED_TOOLING` into test/matrix decisions; add unconditional `meta` job running `actionlint` + `renovate-config-validator` as a CI config tripwire

## Test plan

- [ ] CI passes on this PR (actionlint, zizmor, renovate-config-validator via meta job)
- [ ] Verify `meta` job runs unconditionally
- [ ] Confirm path-filter changes trigger full CI on `.github/` and `tools/` modifications