### PR TITLE
fix(release): add allow_zero_version to prevent premature 1.0.0 bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -425,6 +425,7 @@ exclude = ["tests", "examples"]
 [tool.semantic_release]
 commit_parser = "conventional"
 major_on_zero = false
+allow_zero_version = true
 tag_format = "v{version}"
 version_variables = ["src/pyhaul/_version.py:__version__"]
 build_command = "uv lock --upgrade-package pyhaul"


### PR DESCRIPTION
## Summary

- PSR v10 changed `allow_zero_version` default to `false`, causing any release from a `0.x.x` version to force-bump to `1.0.0`
- Add `allow_zero_version = true` to `[tool.semantic_release]` to stay in zerover until an intentional 1.0 decision

## Test plan

- [ ] CI passes
- [ ] After merge, `uv run semantic-release --noop version --print` produces `0.6.1`