### PR TITLE
chore(release): v0.6.1

### DIFF
--- a/src/pyhaul/_version.py
+++ b/src/pyhaul/_version.py
@@ -1,3 +1,3 @@
 """Package version (stamped by python-semantic-release)."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.12"
 
 [options]
-exclude-newer = "2026-04-29T21:46:27.372168Z"
+exclude-newer = "2026-04-30T01:08:20.842432Z"
 exclude-newer-span = "PT72H"
 
 [[package]]


### PR DESCRIPTION
## Summary

- Stamp version to 0.6.1 (`_version.py`, `uv.lock`)

### Changes since 0.6.0

- fix(release): add `allow_zero_version` to prevent premature 1.0.0 bump
- ci: harden attestation verification, Renovate tiering, and path-filter scope
- ci: upgrade action dependencies to latest releases
- build: migrate to hatchling + PSR with Clean Room release workflow