### PR TITLE
fix(release): add --repo flag to gh release upload and upgrade download-artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
           path: dist/
@@ -86,7 +86,7 @@ jobs:
           TAG: ${{ github.ref_name }}
 
       - name: Upload assets to release
-        run: gh release upload "$TAG" dist/*
+        run: gh release upload "$TAG" dist/* --repo "$GITHUB_REPOSITORY"
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

- `gh release upload` in the `upload-immutable-assets` job failed on v0.6.1 release because it requires `--repo` when no git checkout is present
- Also upgrades `download-artifact` from v7.0.0 to v8.0.1 SHA pin to match the publish job

## Context

The v0.6.1 PyPI publish succeeded. The GitHub Release draft was created but asset upload failed. This fix prevents the issue on future releases.