### PR TITLE
docs: fix mkdocs strict autoref targets for async guide

### DIFF
--- a/docs/guides/async.md
+++ b/docs/guides/async.md
@@ -386,12 +386,12 @@ to run the sync `haul()` in a thread without blocking the event loop:
 either a synchronous callable or one whose return value is awaitable (for example
 `async def`). The engine awaits each chunk's hook before reading the next chunk,
 so you can push updates over websockets or similar without wrapping each call in
-[`asyncio.create_task`][asyncio.create_task]. Keep work bounded — progress runs on the
+[`asyncio.create_task`](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task). Keep work bounded — progress runs on the
 download's critical path.
 
 [`haul()`][pyhaul.engine.haul] still accepts only synchronous callbacks.
 
-Pass a [`HaulState`][pyhaul._types.HaulState] to track progress. Example with a sync hook:
+Pass a [`HaulState`][pyhaul.HaulState] to track progress. Example with a sync hook:
 
 ```python
 import asyncio
@@ -435,5 +435,5 @@ asyncio.run(main())
     **Caller-owned** deadlines — `asyncio.wait_for(...)`, `asyncio.Task.cancel()`, or
     cooperative cancellation — surface as `asyncio.TimeoutError` or
     `asyncio.CancelledError`. Those bypass adapter translation and are **not**
-    turned into [`PartialHaulError`][pyhaul._types.PartialHaulError]; treat them as
+    turned into [`PartialHaulError`][pyhaul.PartialHaulError]; treat them as
     application policy, not transport failure.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -12,6 +12,10 @@
 
 ## Types
 
+::: pyhaul._types.AsyncProgressCallback
+    options:
+      heading_level: 3
+
 ::: pyhaul._types.CompleteHaul
     options:
       heading_level: 3

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -27,6 +27,7 @@ HaulError
 | `ControlFileError` | `.part.ctrl` is corrupt or version-mismatched. | Auto-recovers — corrupt checkpoint is discarded on next attempt |
 | `DestinationError` | Destination path can't accommodate sidecar files. | No — fix the path |
 | *(native)* | Transport errors (`httpx.ReadTimeout`, `requests.ConnectionError`, etc.) pass through unwrapped. | Usually yes |
+| `TransportError` | Translated adapter / client I/O failure (timeout, TLS, reset, …) before pyhaul can complete the response. | Usually yes |
 
 ## Details
 
@@ -59,5 +60,25 @@ sensitive values in logs.
       show_source: false
 
 ::: pyhaul._types.DestinationError
+    options:
+      show_source: false
+
+::: pyhaul.transport.errors.TransportError
+    options:
+      show_source: false
+
+::: pyhaul.transport.errors.TransportConnectionError
+    options:
+      show_source: false
+
+::: pyhaul.transport.errors.TransportTLSError
+    options:
+      show_source: false
+
+::: pyhaul.transport.errors.TransportHTTPError
+    options:
+      show_source: false
+
+::: pyhaul.transport.errors.TransportUnsupportedError
     options:
       show_source: false


### PR DESCRIPTION
Resolves mkdocs-autorefs warnings under `--strict`: document `AsyncProgressCallback` and `TransportError` hierarchy in reference pages, link `asyncio.create_task` to CPython docs, and use `pyhaul._types` / `pyhaul.transport.errors` identifiers that exist in the inventory.